### PR TITLE
MinC1.1 – F39: Tighten Login Flow (auth UX, session control, logout/back)

### DIFF
--- a/minc-vegu-backend/minc_login_init/__init__.py
+++ b/minc-vegu-backend/minc_login_init/__init__.py
@@ -101,6 +101,8 @@ def run(req: func.HttpRequest) -> func.HttpResponse:
                 "success": True,
                 "mincId": user.get("mincId"),
                 "email": user.get("email"),
+                "displayName": user.get("displayName") or user.get("firstName"),
+                "roles": user.get("roles", []),
                 "failedLoginCount": int(user.get("failedLoginCount", 0)),
                 "lockoutUntil": user.get("lockoutUntil"),
             },

--- a/minc-vegu-backend/minc_login_password/__init__.py
+++ b/minc-vegu-backend/minc_login_password/__init__.py
@@ -1,4 +1,6 @@
 # minc_login_password/__init__.py
+# V1.1
+
 import json
 import logging
 from datetime import datetime, timezone
@@ -100,7 +102,6 @@ def run(req: func.HttpRequest) -> func.HttpResponse:
         # 4) Success — clear failures; ensure status active
         reset_failures(user)
         user["status"] = "active"
-        user["lastLoginAt"] = datetime.now(timezone.utc).isoformat()
         cont.replace_item(user, user)
 
         return _json({

--- a/minc-vegu-backend/minc_verify_email_otp/__init__.py
+++ b/minc-vegu-backend/minc_verify_email_otp/__init__.py
@@ -3,8 +3,10 @@ import json
 import azure.functions as func
 import logging
 from function_app import app
+from datetime import datetime, timezone
 from shared.auth import http_auth_level
 from shared.email_otp import verify_email_otp   # <-- change this import
+from shared.cosmos_client import users_container
 
 def _json(obj, status=200):
     return func.HttpResponse(json.dumps(obj), status_code=status, mimetype="application/json")
@@ -26,6 +28,28 @@ def run(req: func.HttpRequest) -> func.HttpResponse:
 
     ok, reason = verify_email_otp(email=email, otp=otp, context=context)
     if ok:
+        # Post-OTP success → this is the true login point.
+        try:
+            cont = users_container()
+            items = list(cont.query_items(
+                query="SELECT TOP 1 * FROM c WHERE c.email = @em",
+                parameters=[{"name": "@em", "value": email}],
+                enable_cross_partition_query=True
+            ))
+            if items:
+                user = items[0]
+                user["lastLoginAt"] = datetime.now(timezone.utc).isoformat()
+                # OTP confirms identity → clear counters/lock if any lingered
+                user["failedLoginCount"] = 0
+                user["lastFailedAt"] = None
+                user["lockoutUntil"] = None
+                cont.replace_item(user, user)
+            else:
+                logging.warning(f"[OTP] success but user not found for email={email}")
+        except Exception as e:
+            # Best-effort: do not block login if the write fails
+            logging.exception(f"[OTP] lastLoginAt update failed: {e}")
         return _json({"success": True})
+        
     logging.warning(f"[OTP] verify failed: {reason}")
     return _json({"success": False, "error": reason or "OTP verification failed."}, 400)

--- a/minc-vegu-frontend/package-lock.json
+++ b/minc-vegu-frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.8.2"
       },
       "devDependencies": {
@@ -2899,6 +2900,15 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3115,14 +3125,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3281,9 +3291,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
-      "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
+      "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3292,7 +3302,7 @@
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/minc-vegu-frontend/package.json
+++ b/minc-vegu-frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.8.2"
   },
   "devDependencies": {

--- a/minc-vegu-frontend/src/App.jsx
+++ b/minc-vegu-frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from "react-router-dom";
 import MinCMainDashboard from "./pages/MinCMainDashboard";
 import MinCVeguDashboard from "./pages/MinCVeguDashboard";
 import MinCLandingPage from "./pages/MinCLandingPage";
@@ -6,16 +6,57 @@ import MinCLoginPage from "./pages/MinCLoginPage";
 import MinCRegisterPage from "./pages/MinCRegisterPage";
 import MinCContactSupportPage from "./pages/MinCContactSupportPage";
 
+function getSessionUser() {
+  try {
+    const raw = sessionStorage.getItem("mincUser");
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+// RequireAuth: protects private routes
+function RequireAuth({ children }) {
+  const loc = useLocation();
+  const user = getSessionUser();
+  if (!user) {
+    // send to login and replace history so Back won't return here
+    return <Navigate to="/login" replace state={{ from: loc }} />;
+  }
+  return children;
+}
+
+// RedirectIfAuthed: keeps logged-in users out of login/register
+function RedirectIfAuthed({ children }) {
+  const user = getSessionUser();
+  if (user) {
+    return <Navigate to="/dashboard" replace />;
+  }
+  return children;
+}
+
 function App() {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<MinCLandingPage />} />
-        <Route path="/login" element={<MinCLoginPage />} />
+
+        {/* Guest-only routes */}
+        <Route
+          path="/login"
+          element={
+            <RedirectIfAuthed>
+              <MinCLoginPage />
+            </RedirectIfAuthed>
+          }
+        />
         <Route path="/register" element={<MinCRegisterPage />} />
         <Route path="/contact" element={<MinCContactSupportPage />} />
-        <Route path="/dashboard" element={<MinCMainDashboard />} />
-        <Route path="/vegu" element={<MinCVeguDashboard />} />
+        
+        {/* Protected routes */}
+        <Route path="/dashboard" element={<RequireAuth><MinCMainDashboard /></RequireAuth>} />
+        <Route path="/vegu" element={<RequireAuth><MinCVeguDashboard /></RequireAuth>} />
+
       </Routes>
     </Router>
   );

--- a/minc-vegu-frontend/src/pages/MinCLoginPage.jsx
+++ b/minc-vegu-frontend/src/pages/MinCLoginPage.jsx
@@ -137,6 +137,8 @@ export default function MinCLoginPage() {
       setUser({
         mincId: data.mincId,
         email: data.email,
+        displayName: data.displayName,
+        roles: Array.isArray(data.roles) ? data.roles : [],
         failedAttempts: data.failedLoginCount ?? 0,
         lockoutUntil: data.lockoutUntil ?? null,
       });

--- a/minc-vegu-frontend/src/pages/MinCLoginPage.jsx
+++ b/minc-vegu-frontend/src/pages/MinCLoginPage.jsx
@@ -1,4 +1,5 @@
-// src/pages/MinCLoginPage.jsx
+// src/pages/MinCLoginPage.jsx v1.1
+
 import React, { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import "../styles/MinCGlobal.css";
@@ -115,9 +116,15 @@ export default function MinCLoginPage() {
       if (res.status === 404) { setError("MinC user not found."); return; }
       if (res.status === 403) {
         const j = await readErr(res);
-        const untilIso = j.lockoutUntil || j.lockout_until;
-        const until = untilIso ? ` until ${formatLockoutLocal(untilIso)}` : "";
-        setError(`Account locked${until}`);
+        const reason = (j.reason || "").toLowerCase();
+        if (reason === "locked") {
+          const untilIso = j.lockoutUntil || j.lockout_until;
+          const until = untilIso ? ` until ${formatLockoutLocal(untilIso)}` : "";
+          setError(`Account locked${until}`);
+        } else {
+          // show server-provided text or our standard copy
+          setError(j.error || "Account is not active. Contact MinC support.");
+        }
         return;
       }
       if (!res.ok) {
@@ -177,9 +184,14 @@ const handleSubmitPassword = async (e) => {
     // handle known statuses
     if (res.status === 403) {
       const j = await readErr(res);
-      const untilIso = j.lockoutUntil || j.lockout_until;
-      const until = untilIso ? ` until ${formatLockoutLocal(untilIso)}` : "";
-      setError(`Account locked${until}`);
+      const reason = (j.reason || "").toLowerCase();
+      if (reason === "locked") {
+        const untilIso = j.lockoutUntil || j.lockout_until;
+        const until = untilIso ? ` until ${formatLockoutLocal(untilIso)}` : "";
+        setError(`Account locked${until}`);
+      } else {
+        setError(j.error || "Account is not active. Contact MinC support.");
+      }
       setStep(1);
       return;
     }

--- a/minc-vegu-frontend/src/pages/MinCLoginPage.jsx
+++ b/minc-vegu-frontend/src/pages/MinCLoginPage.jsx
@@ -283,7 +283,7 @@ const handleSubmitPassword = async (e) => {
 
       // Success — keep the minimal session (same as before)
       sessionStorage.setItem("mincUser", JSON.stringify(user));
-      navigate("/dashboard");
+      navigate("/dashboard", { replace: true });
     } catch (err) {
       console.error("[MinC] OTP verify error", err);
       setError("Error verifying OTP.");

--- a/minc-vegu-frontend/src/pages/MinCLoginPage.jsx
+++ b/minc-vegu-frontend/src/pages/MinCLoginPage.jsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { FaArrowLeft } from "react-icons/fa"; 
 import "../styles/MinCGlobal.css";
 import { CONFIG } from "../utils/config";
 import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
@@ -326,6 +327,20 @@ const handleSubmitPassword = async (e) => {
 
       <div className="page-wrap">
         <div className="auth-card">
+
+          {/* 🔴 Back Button (Top-left inside card) */}
+          <div
+            className="minc-back-container"
+            role="button"
+            tabIndex={0}
+            onClick={() => navigate("/")}
+            onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && navigate("/")}
+            aria-label="Back to Landing"
+          >
+            <FaArrowLeft className="minc-back-icon" />
+            <div className="minc-back-label">Back</div>
+          </div>
+
           <h1 className="auth-title">MinC Portal Login</h1>
           <p className="auth-sub">Sign in with your MINC ID (no spaces) or Email*</p>
 
@@ -450,11 +465,7 @@ const handleSubmitPassword = async (e) => {
             </form>
           )}
 
-          <div style={{ textAlign: "center", marginTop: 14 }}>
-            <Link to="/" className="link-ghost">
-              Back to Landing
-            </Link>
-          </div>
+
         </div>
       </div>
     </>

--- a/minc-vegu-frontend/src/pages/MinCMainDashboard.jsx
+++ b/minc-vegu-frontend/src/pages/MinCMainDashboard.jsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { FaSignOutAlt } from "react-icons/fa";
 import MMSLogo from "../assets/MMS_Logo.png";
 import VEGULogo from "../assets/VEGU_Logo.png";
 import "../styles/MinCDashboard.css";
@@ -9,21 +10,46 @@ import "../styles/MinCDashboard.css";
 export default function MinCMainDashboard() {
   const nav = useNavigate();
   const [showDialog, setShowDialog] = useState(false);
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
+
   const rawUser = sessionStorage.getItem("mincUser");
   const user = rawUser ? JSON.parse(rawUser) : null;
+
+  const handleLogout = () => {
+    setShowLogoutModal(true);
+  };
 
   return (
     <div className="minc-page">
       <div className="minc-dashboard-card">
-        <h1 className="minc-title">MinC Main Dashboard</h1>
+
+        {/* Logout button (top-right) */}
+        <div
+          className="logout-container"
+          role="button"
+          tabIndex={0}
+          onClick={handleLogout}
+          onKeyDown={(e) =>
+            (e.key === "Enter" || e.key === " ") && handleLogout()
+          }
+          aria-label="Logout"
+        >
+          <FaSignOutAlt className="logout-button" title="Logout" />
+          <div className="logout-label">Logout</div>
+        </div>
+
+        <h1 className="minc-title">MinC Dashboard</h1>
+
         {user && (
-  <div className="minc-user-info">
-    <div className="minc-user-name">{user.displayName}</div>
-    <div className="minc-user-roles">{(user.roles || []).join(", ")}</div>
-  </div>
-)}
+          <div className="minc-user-info">
+            <div className="minc-user-name">{user.displayName}</div>
+            <div className="minc-user-roles">
+              {(user.roles || []).join(", ")}
+            </div>
+          </div>
+        )}
+
         <div className="minc-brand-grid">
-          {/* MMS Card */}
           <div
             className="minc-brand-card"
             onClick={() => setShowDialog(true)}
@@ -31,8 +57,6 @@ export default function MinCMainDashboard() {
           >
             <img src={MMSLogo} alt="MMS" className="minc-brand-logo" />
           </div>
-
-          {/* VEGU Card */}
           <div
             className="minc-brand-card"
             onClick={() => nav("/minc-vegu-dashboard")}
@@ -43,9 +67,47 @@ export default function MinCMainDashboard() {
         </div>
       </div>
 
-      {/* Simple modal for MMS */}
+      {/* Logout Modal */}
+      {showLogoutModal && (
+        <div className="minc-modal-backdrop" onClick={() => setShowLogoutModal(false)}>
+          <div
+            className="minc-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="logout-modal-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="logout-modal-title" className="minc-modal-title">
+              Confirm Logout
+            </h3>
+            <p className="minc-modal-text">Are you sure you want to logout?</p>
+            <div className="minc-modal-actions">
+              <button
+                className="btn btn-danger"
+                onClick={() => {
+                  sessionStorage.clear();
+                  nav("/login", { replace: true });
+                }}
+              >
+                Yes, Logout
+              </button>
+              <button
+                className="btn btn-secondary"
+                onClick={() => setShowLogoutModal(false)}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* MMS Coming Soon Modal */}
       {showDialog && (
-        <div className="minc-modal-backdrop" onClick={() => setShowDialog(false)}>
+        <div
+          className="minc-modal-backdrop"
+          onClick={() => setShowDialog(false)}
+        >
           <div
             className="minc-modal"
             role="dialog"
@@ -53,10 +115,15 @@ export default function MinCMainDashboard() {
             aria-labelledby="mms-modal-title"
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 id="mms-modal-title" className="minc-modal-title">Heads up</h3>
+            <h3 id="mms-modal-title" className="minc-modal-title">
+              Heads up
+            </h3>
             <p className="minc-modal-text">This feature is coming soon.</p>
             <div className="minc-modal-actions">
-              <button className="btn btn-primary" onClick={() => setShowDialog(false)}>
+              <button
+                className="btn btn-primary"
+                onClick={() => setShowDialog(false)}
+              >
                 OK
               </button>
             </div>

--- a/minc-vegu-frontend/src/pages/MinCMainDashboard.jsx
+++ b/minc-vegu-frontend/src/pages/MinCMainDashboard.jsx
@@ -1,4 +1,5 @@
-// src/pages/MinCMainDashboard.jsx
+// src/pages/MinCMainDashboard.jsx v1.1
+
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import MMSLogo from "../assets/MMS_Logo.png";
@@ -8,11 +9,19 @@ import "../styles/MinCDashboard.css";
 export default function MinCMainDashboard() {
   const nav = useNavigate();
   const [showDialog, setShowDialog] = useState(false);
+  const rawUser = sessionStorage.getItem("mincUser");
+  const user = rawUser ? JSON.parse(rawUser) : null;
 
   return (
     <div className="minc-page">
       <div className="minc-dashboard-card">
         <h1 className="minc-title">MinC Main Dashboard</h1>
+        {user && (
+  <div className="minc-user-info">
+    <div className="minc-user-name">{user.displayName}</div>
+    <div className="minc-user-roles">{(user.roles || []).join(", ")}</div>
+  </div>
+)}
         <div className="minc-brand-grid">
           {/* MMS Card */}
           <div

--- a/minc-vegu-frontend/src/styles/MinCDashboard.css
+++ b/minc-vegu-frontend/src/styles/MinCDashboard.css
@@ -33,7 +33,7 @@
   gap: 0.75rem;
   padding: 1rem;
   border-radius: 14px;
-  background: #e8f2ea;
+  background: #fff;
   box-shadow: 0 4px 16px rgba(0,0,0,.07);
   cursor: pointer;
   user-select: none;
@@ -50,6 +50,7 @@
   height: 200px;         /* square container */
   object-fit: contain;   /* keep aspect ratio, no cropping */
   display: block;
+  
 }
 
 /* Label under each logo */
@@ -174,4 +175,102 @@
   font-size: 0.9rem;
   color: #666;
   margin-top: 4px;
+}
+
+/* --- Logout control (top-right) --- */
+.minc-logout-container {
+  position: absolute;
+  top: 16px;
+  right: 20px;
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  padding: 6px 8px;
+  border-radius: 10px;
+}
+
+.minc-logout-button {
+  font-size: 1.6rem;
+  color: #F1663D; /* brand orange */
+  display: block;
+  margin: 0 auto;
+}
+
+.minc-logout-label {
+  font-size: 0.72rem;
+  color: grey;
+  margin-top: 2px;
+  font-family: "Exo 2", sans-serif;
+}
+
+.minc-logout-container:focus {
+  outline: 2px solid rgba(241, 102, 61, 0.6);
+  outline-offset: 2px;
+}
+
+/* Logout button styles */
+.minc-dashboard-card {
+  background: #E8F5E9;
+  border-radius: 36px;
+  padding: 2rem;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+  border: 3px solid #F1663D;
+  position: relative;   /* 👈 NEW: makes logout-container anchor inside */
+  text-align: center;
+}
+
+/* Logout button styles (unchanged, but now anchored correctly) */
+.logout-container {
+  position: absolute;
+  top: 15px;
+  right: 25px;
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  padding: 6px 8px;
+  border-radius: 8px;
+}
+
+.logout-button {
+  font-size: 1.8rem;
+  color: #F1663D;
+  cursor: pointer;
+  display: block;
+  margin: 0 auto;
+}
+
+.logout-label {
+  font-size: 0.7rem;
+  color: grey;
+  margin-top: 2px;
+}
+
+/* Modal actions */
+.minc-modal-actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;   /* 👈 space between buttons */
+  margin-top: 1.5rem;
+}
+
+/* Button base style */
+.minc-modal-actions .btn {
+  padding: 10px 20px;
+  border-radius: 6px;
+  font-weight: bold;
+  cursor: pointer;
+  font-family: 'Exo2', sans-serif;
+  border: none;
+}
+
+/* Danger button (Logout) */
+.minc-modal-actions .btn-danger {
+  background-color: #F1663D;
+  color: white;
+}
+
+/* Secondary button (Cancel) */
+.minc-modal-actions .btn-secondary {
+  background-color: #F5EE1F;
+  color: #1B5228;
 }

--- a/minc-vegu-frontend/src/styles/MinCDashboard.css
+++ b/minc-vegu-frontend/src/styles/MinCDashboard.css
@@ -156,3 +156,22 @@
   outline: 3px solid rgba(27,82,40,.55);
   outline-offset: 2px;
 }
+
+.minc-user-info {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.minc-user-name {
+  font-family: Orbitron, sans-serif;
+  font-size: 1.4rem;
+  color: #F1663D; /* Dark Green */
+  font-weight: 600;
+}
+
+.minc-user-roles {
+  font-family: Exo 2, sans-serif;
+  font-size: 0.9rem;
+  color: #666;
+  margin-top: 4px;
+}

--- a/minc-vegu-frontend/src/styles/MinCGlobal.css
+++ b/minc-vegu-frontend/src/styles/MinCGlobal.css
@@ -196,6 +196,7 @@ img { max-width: 100%; display: block; }
   border-radius: 24px;
   background: #f6fff8;
   box-shadow: 0 18px 60px rgba(0,0,0,.10);
+  position: relative;
 }
 
 .auth-title {
@@ -315,4 +316,36 @@ img { max-width: 100%; display: block; }
 .input, .remember, button, .link-underline {
   font-family: "Exo 2", sans-serif;
   font-size: 18px;
+}
+
+/* Back button container */
+.minc-back-container {
+  position: absolute;
+  top: 15px;
+  left: 15px;
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  padding: 6px 8px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.minc-back-icon {
+  font-size: 1.5rem;
+  color: #F1663D;   /* red */
+}
+
+.minc-back-label {
+  font-size: 0.7rem;
+  color: grey;
+  margin-top: 2px;
+}
+
+/* 🔑 Add padding-top to auth-card so content clears the back button */
+.auth-card {
+  position: relative;
+  padding-top: 60px;   /* gives space under Back button */
 }


### PR DESCRIPTION
This PR delivers Feature F39 (MinC1.1). It tightens the login flow, hardens session navigation, and harmonizes UI across Login and Main Dashboard.

Key changes
	•	Session control
	•	Added route guards to protect /dashboard and /vegu; guest-only redirect for /login.
	•	Use navigate(..., { replace: true }) after OTP success and on logout to prevent back-nav into protected screens.
	•	Accurate account-state messaging
	•	FE now distinguishes locked vs not_active/other using reason from BE responses at both init and password steps.
	•	User info on dashboard
	•	Displays displayName and roles under “MinC Main Dashboard”.
	•	Backend minc-login-init now returns displayName and roles.
	•	Logout (Main Dashboard)
	•	Top-right Logout icon + label, confirm modal, clears session, routes to /login with replace:true.
	•	Modal buttons styled to brand and spaced with gap.
	•	Back (Login)
	•	Replaced bottom “Back to Landing” link with top-left Back icon inside the login card; routes to / (Landing).
	•	Styling + polish
	•	Positioned controls relative to cards (position: relative on .minc-dashboard-card and .auth-card).
	•	Added/updated CSS in MinCDashboard.css and MinCGlobal.css.
	•	Installed react-icons for consistent iconography.