### PR TITLE
feat(institutions): Add Update Institution workflow with admin notes and contact fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ minc-vegu-backend/.vscode/settings.json
 minc-vegu-backend/.vscode/tasks.json
 minc-vegu-frontend/.env*
 minc-vegu-frontend/src/utils/config.js
+minc-vegu-backend/local-settings-params.txt
 Summaries/

--- a/minc-vegu-backend/function_app.py
+++ b/minc-vegu-backend/function_app.py
@@ -12,3 +12,4 @@ import minc_send_email_otp      # noqa: F401
 import minc_verify_email_otp    # noqa: F401
 import vegu_institutions_search  # noqa: F401
 import vegu_institutions_get     # noqa: F401
+import vegu_institutions_update  # noqa: F401

--- a/minc-vegu-backend/function_app.py
+++ b/minc-vegu-backend/function_app.py
@@ -10,3 +10,5 @@ import minc_login_init          # noqa: F401
 import minc_login_password      # noqa: F401
 import minc_send_email_otp      # noqa: F401
 import minc_verify_email_otp    # noqa: F401
+import vegu_institutions_search  # noqa: F401
+import vegu_institutions_get     # noqa: F401

--- a/minc-vegu-backend/shared/vegu_cosmos_client.py
+++ b/minc-vegu-backend/shared/vegu_cosmos_client.py
@@ -143,7 +143,8 @@ def update_institution_fields(vg_id: str, patch: Dict[str, Any]) -> Dict[str, An
         "name","address1","address2","city","state","postal_code","country",
         "complaint_email","complaint_phone","country_code","timezone",
         "status","plan_type","subscription_expiry","institution_type","institution_category",
-        "personnel_name","comment","admin_notes","max_responders","testing","last_updated","updated_at"
+        "personnel_name","comment","admin_notes","max_responders","testing","last_updated","updated_at",
+        "primary_contact_name","primary_contact_phone","primary_contact_email", "website_url",
     }
 
     cont = institutions_container()

--- a/minc-vegu-backend/shared/vegu_cosmos_client.py
+++ b/minc-vegu-backend/shared/vegu_cosmos_client.py
@@ -1,0 +1,182 @@
+# shared/vegu_cosmos_client.py v1.3
+# MinC → VEGU Cosmos access (scoped, least-privilege)
+
+from __future__ import annotations
+import os
+from typing import Any, Dict, List, Optional, Tuple
+from azure.cosmos import CosmosClient
+from azure.cosmos.exceptions import CosmosHttpResponseError
+
+# ---- ENV (MinC) ----
+VEGU_COSMOS_URI = os.getenv("VEGU_COSMOS_URI")
+VEGU_COSMOS_KEY = os.getenv("VEGU_COSMOS_KEY")
+VEGU_COSMOS_DB  = os.getenv("VEGU_COSMOS_DB", "vegu3-main")
+
+# Containers we will touch from MinC
+CN_INSTITUTIONS = "institutions"
+
+# ----- client helpers -----
+def _client() -> CosmosClient:
+    if not VEGU_COSMOS_URI or not VEGU_COSMOS_KEY:
+        raise RuntimeError("VEGU Cosmos credentials are not configured.")
+    return CosmosClient(VEGU_COSMOS_URI, VEGU_COSMOS_KEY)
+
+def _db():
+    return _client().get_database_client(VEGU_COSMOS_DB)
+
+def institutions_container():
+    return _db().get_container_client(CN_INSTITUTIONS)
+
+# ----- read helpers -----
+def institutions_count(country: Optional[str] = None) -> int:
+    """
+    Fast-ish count via query. If country is provided, filter by that partition.
+    """
+    cont = institutions_container()
+    if country:
+        q = "SELECT VALUE COUNT(1) FROM c WHERE c.type='institution' AND c.country=@country"
+        params = [{"name":"@country","value":country}]
+        it = cont.query_items(query=q, parameters=params, enable_cross_partition_query=True)
+    else:
+        q = "SELECT VALUE COUNT(1) FROM c WHERE c.type='institution'"
+        it = cont.query_items(query=q, enable_cross_partition_query=True)
+    for v in it:
+        return int(v)
+    return 0
+
+def get_institution_by_vg_id(vg_id: str) -> Optional[Dict[str, Any]]:
+    """
+    Query by exact vg_id. Partition key is /country, so we query cross-partition.
+    """
+    cont = institutions_container()
+    q = "SELECT TOP 1 * FROM c WHERE c.type='institution' AND c.vg_id=@vg_id"
+    params = [{"name":"@vg_id","value":vg_id}]
+    items = list(cont.query_items(query=q, parameters=params, enable_cross_partition_query=True))
+    return items[0] if items else None
+
+def list_institutions(
+    skip: int = 0,
+    limit: int = 25,
+    country: Optional[str] = None,
+    status: Optional[str] = None,
+    plan_type: Optional[str] = None,
+    sort_by: str = "updated_at",
+    sort_dir: str = "DESC",
+) -> Tuple[List[Dict[str,Any]], int]:
+    """
+    Paginated list. Returns (items, total_count).
+    """
+    cont = institutions_container()
+
+    filters = ["c.type='institution'"]
+    params: List[Dict[str,Any]] = []
+
+    if country:
+        filters.append("c.country=@country")
+        params.append({"name":"@country","value":country})
+    if status:
+        filters.append("LOWER(c.status)=@status")
+        params.append({"name":"@status","value":status.lower()})
+    if plan_type:
+        filters.append("LOWER(c.plan_type)=@plan")
+        params.append({"name":"@plan","value":plan_type.lower()})
+
+    where = " AND ".join(filters)
+    order = sort_by if sort_by in {"name","vg_id","updated_at","created_at","subscription_expiry"} else "updated_at"
+    direction = "DESC" if sort_dir.upper() == "DESC" else "ASC"
+
+    # total
+    qc = f"SELECT VALUE COUNT(1) FROM c WHERE {where}"
+    total_iter = cont.query_items(query=qc, parameters=params, enable_cross_partition_query=True)
+    total = next(iter(total_iter), 0)
+
+    # page
+    qp = f"SELECT * FROM c WHERE {where} ORDER BY c.{order} {direction} OFFSET @skip LIMIT @limit"
+    items_iter = cont.query_items(
+        query=qp,
+        parameters=params + [{"name":"@skip","value":skip},{"name":"@limit","value":limit}],
+        enable_cross_partition_query=True,
+    )
+    items = list(items_iter)
+    return items, int(total)
+
+def search_institutions(
+    text: str,
+    fields: Optional[List[str]] = None,
+    limit: int = 50
+) -> List[Dict[str,Any]]:
+    """
+    Multi-field search. Supports vg_id pattern, name, city, email.
+    Cosmos SQL allows STARTSWITH / CONTAINS (case-sensitive by default),
+    so we normalize both sides to lower() for consistency.
+    """
+    cont = institutions_container()
+    text = (text or "").strip()
+    if not text:
+        return []
+
+    fields = fields or ["vg_id","name","city","complaint_email","institution_type","institution_category"]
+    # Build a lower(...) OR chain
+    or_terms = []
+    for f in fields:
+        or_terms.append(f"CONTAINS(LOWER(c.{f}), @q)")
+    where = " OR ".join(or_terms)
+
+    q = f"""
+      SELECT TOP {max(1, min(limit, 200))} *
+      FROM c
+      WHERE c.type='institution' AND ({where})
+      ORDER BY c.updated_at DESC
+    """
+    params = [{"name":"@q", "value": text.lower()}]
+    items = list(cont.query_items(query=q, parameters=params, enable_cross_partition_query=True))
+    return items
+
+# ----- write helper (safe replace) -----
+def update_institution_fields(vg_id: str, patch: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Read → merge → replace.
+    Requires we can determine partition key (country) from the existing doc.
+    Only updates whitelisted fields (defensive).
+    """
+    allowed = {
+        "name","address1","address2","city","state","postal_code","country",
+        "complaint_email","complaint_phone","country_code","timezone",
+        "status","plan_type","subscription_expiry","institution_type","institution_category",
+        "personnel_name","comment","admin_notes","max_responders","testing","last_updated","updated_at"
+    }
+
+    cont = institutions_container()
+    current = get_institution_by_vg_id(vg_id)
+    if not current:
+        raise ValueError("Institution not found")
+
+    # Merge only allowed keys
+    new_doc = dict(current)
+    for k, v in patch.items():
+        if k in allowed:
+            new_doc[k] = v
+
+    # Always bump updated_at (UTC ISO) if caller didn't supply
+    from datetime import datetime, timezone
+    new_doc.setdefault("updated_at", datetime.now(timezone.utc).isoformat())
+
+    # Partition key is /country; ensure it exists
+    pk = new_doc.get("country")
+    if not pk:
+        raise ValueError("Institution document missing 'country' for partition key.")
+
+    try:
+        # Replace by (id, partition_key)
+        return cont.replace_item(item=new_doc["id"], body=new_doc, partition_key=pk)  # SDK ≥ 4.7 supports partition_key kw
+    except TypeError:
+        # Older SDK signature fallback
+        return cont.replace_item(item=new_doc, body=new_doc)  # relies on body['country']
+
+# (Optional) existence checks
+def institution_name_exists(name: str) -> bool:
+    cont = institutions_container()
+    q = "SELECT VALUE COUNT(1) FROM c WHERE c.type='institution' AND c.name=@name"
+    params = [{"name":"@name","value":name}]
+    count = next(iter(cont.query_items(query=q, parameters=params, enable_cross_partition_query=True)), 0)
+    return int(count) > 0

--- a/minc-vegu-backend/vegu_institutions_get/__init__.py
+++ b/minc-vegu-backend/vegu_institutions_get/__init__.py
@@ -1,0 +1,31 @@
+# vegu_institutions_get/__init__.py  v1.3
+import json
+import azure.functions as func
+from function_app import app
+from shared.auth import http_auth_level          # keep same auth behavior as others
+from shared.vegu_cosmos_client import get_institution_by_vg_id
+
+def _json(obj, status=200):
+    return func.HttpResponse(json.dumps(obj), status_code=status, mimetype="application/json")
+
+@app.function_name(name="vegu_institutions_get")
+@app.route(route="vegu-institutions/{vg_id}", methods=["GET"], auth_level=http_auth_level())
+def run(req: func.HttpRequest) -> func.HttpResponse:
+    vg_id = req.route_params.get("vg_id", "").strip()
+    if not vg_id:
+        return _json({"success": False, "error": "Missing vg_id"}, 400)
+
+    try:
+        doc = get_institution_by_vg_id(vg_id)
+        if not doc:
+            return _json({"success": False, "error": "Institution not found"}, 404)
+
+        # remove noisy cosmos fields if present
+        etag = doc.pop("_etag", "")
+        for f in ("_rid", "_self", "_attachments", "_ts"):
+            doc.pop(f, None)
+
+        return _json({"success": True, "institution": doc, "etag": etag})
+    except Exception as e:
+        # log if you want; keep generic error outward
+        return _json({"success": False, "error": "server_error"}, 500)

--- a/minc-vegu-backend/vegu_institutions_search/__init__.py
+++ b/minc-vegu-backend/vegu_institutions_search/__init__.py
@@ -1,0 +1,74 @@
+# vegu_institutions_search/__init__.py
+# Route: GET /api/vegu-institutions-search?q=<text>&limit=20
+# - Partial, case-insensitive, multi-token (AND across tokens, OR across fields)
+# - Returns lightweight rows for the FE typeahead
+
+import json
+from urllib.parse import unquote_plus
+
+import azure.functions as func
+from function_app import app
+from shared.auth import http_auth_level
+from shared.vegu_cosmos_client import institutions_container
+
+SEARCH_FIELDS = [
+    "vg_id", "name", "city",
+    "complaint_email", "institution_type", "institution_category",
+]
+
+RETURN_FIELDS = ["id", "vg_id", "name", "city", "country", "status"]
+
+MAX_LIMIT = 50
+DEFAULT_LIMIT = 20
+
+
+def _json(payload, status=200):
+    return func.HttpResponse(json.dumps(payload), status_code=status, mimetype="application/json")
+
+
+@app.function_name(name="vegu_institutions_search")
+@app.route(route="vegu-institutions-search", methods=["GET"], auth_level=http_auth_level())
+def run(req: func.HttpRequest) -> func.HttpResponse:
+    try:
+        raw_q = req.params.get("q", "")
+        q = unquote_plus(raw_q).strip()
+        if not q:
+            return _json({"success": False, "error": "Missing query param 'q'."}, 400)
+
+        tokens = [t.lower() for t in q.split() if t.strip()]
+        if not tokens:
+            return _json({"success": False, "error": "Empty search tokens."}, 400)
+
+        try:
+            limit = int(req.params.get("limit", DEFAULT_LIMIT))
+        except ValueError:
+            limit = DEFAULT_LIMIT
+        limit = max(1, min(limit, MAX_LIMIT))
+
+        cont = institutions_container()
+
+        # WHERE: c.type='institution' AND ( ORs per token ) AND (next token) ...
+        clauses = ["c.type='institution'"]
+        params = []
+        for i, tok in enumerate(tokens):
+            pname = f"@t{i}"
+            params.append({"name": pname, "value": tok})
+            ors = [f"CONTAINS(LOWER(c.{f}), {pname})" for f in SEARCH_FIELDS]
+            clauses.append("(" + " OR ".join(ors) + ")")
+        where = " AND ".join(clauses)
+
+        select_fields = ", ".join([f"c.{f}" for f in RETURN_FIELDS])
+        query = f"""
+            SELECT TOP {limit} {select_fields}
+            FROM c
+            WHERE {where}
+            ORDER BY c._ts DESC
+        """
+
+        items = list(cont.query_items(query=query, parameters=params, enable_cross_partition_query=True))
+        return _json({"success": True, "items": items})
+
+    except Exception as e:
+        # Keep logs verbose, response minimal
+        print(f"❌ vegu_institutions_search error: {e}")
+        return _json({"success": False, "error": "server_error"}, 500)

--- a/minc-vegu-backend/vegu_institutions_update/__init__.py
+++ b/minc-vegu-backend/vegu_institutions_update/__init__.py
@@ -1,0 +1,85 @@
+# vegu_institutions_update/__init__.py  v1.3
+import json
+import logging
+import azure.functions as func
+from datetime import datetime, timezone
+from function_app import app
+from shared.auth import http_auth_level
+from shared.vegu_cosmos_client import (
+    get_institution_by_vg_id,
+    update_institution_fields,
+)
+
+def _resp(obj, status=200):
+    return func.HttpResponse(json.dumps(obj), status_code=status, mimetype="application/json")
+
+# Fields we’re OK receiving from FE (extra safety — vegu_cosmos_client also defends)
+ALLOWED_FIELDS = {
+    "name","address1","address2","city","state","postal_code","country",
+    "complaint_email","complaint_phone","country_code","timezone",
+    "status","plan_type","subscription_expiry","institution_type","institution_category",
+    "personnel_name","comment","admin_notes","max_responders","testing","updated_at",
+    "primary_contact_name","primary_contact_phone","primary_contact_email", "website_url",
+}
+
+@app.function_name(name="vegu_institutions_update")
+@app.route(route="vegu-institutions-update", methods=["POST", "PATCH"], auth_level=http_auth_level())
+def run(req: func.HttpRequest) -> func.HttpResponse:
+    try:
+        body = req.get_json()
+    except ValueError:
+        return _resp({"success": False, "error": "Invalid JSON."}, 400)
+
+    vg_id = (body or {}).get("vg_id") or (body or {}).get("id")
+    if not vg_id:
+        return _resp({"success": False, "error": "vg_id is required"}, 400)
+
+    patch_in = (body or {}).get("patch") or {}
+    if not isinstance(patch_in, dict) or not patch_in:
+        return _resp({"success": False, "error": "patch object is required"}, 400)
+
+    # Optional optimistic concurrency
+    client_etag = (body or {}).get("etag")
+
+    # Load current
+    current = get_institution_by_vg_id(vg_id)
+    if not current:
+        return _resp({"success": False, "error": "Institution not found"}, 404)
+
+    # Concurrency: if client provided etag and doesn’t match, ask them to refresh
+    server_etag = current.get("_etag")
+    if client_etag and server_etag and client_etag != server_etag:
+        return _resp({
+            "success": False,
+            "error": "etag_mismatch",
+            "message": "The record was modified by someone else. Refresh and retry.",
+            "etag": server_etag
+        }, 409)
+
+    # Sanitize patch keys (extra layer; the write helper also filters)
+    patch = {k: v for k, v in patch_in.items() if k in ALLOWED_FIELDS}
+
+    if not patch:
+        return _resp({"success": False, "error": "No allowed fields in patch."}, 400)
+    # ALWAYS server-stamp the update time (UTC, ISO8601 Z)
+    patch["updated_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    try:
+        updated = update_institution_fields(vg_id=vg_id, patch=patch)
+    except ValueError as ve:
+        # e.g., missing country (partition) or not found
+        return _resp({"success": False, "error": str(ve)}, 404)
+    except Exception as e:
+        logging.exception("vegu_institutions_update failed")
+        return _resp({"success": False, "error": "server_error"}, 500)
+
+    # Trim noisy cosmos internals but return fresh etag for the client
+    etag = updated.get("_etag")
+    for f in ("_rid","_self","_attachments","_ts"):
+        updated.pop(f, None)
+
+    return _resp({
+        "success": True,
+        "institution": updated,
+        "etag": etag
+    }, 200)

--- a/minc-vegu-frontend/src/App.jsx
+++ b/minc-vegu-frontend/src/App.jsx
@@ -6,6 +6,7 @@ import MinCLoginPage from "./pages/MinCLoginPage";
 import MinCRegisterPage from "./pages/MinCRegisterPage";
 import MinCContactSupportPage from "./pages/MinCContactSupportPage";
 import MinCVeguInstitutionsDashboard from "./pages/MinCVEGUInstitutionsDashboard";
+import MinCVEGUInstitutionUpdate from "./pages/MinCVEGUInstitutionUpdate";
 
 function getSessionUser() {
   try {
@@ -58,7 +59,7 @@ function App() {
         <Route path="/dashboard" element={<RequireAuth><MinCMainDashboard /></RequireAuth>} />
         <Route path="/minc-vegu-dashboard" element={<RequireAuth><MinCVeguDashboard /></RequireAuth>} />
         <Route path="/vegu/institutions" element={<RequireAuth><MinCVeguInstitutionsDashboard /></RequireAuth>} />
-
+        <Route path="/vegu/institutions/update" element={<RequireAuth><MinCVEGUInstitutionUpdate /></RequireAuth>} />
       </Routes>
     </Router>
   );

--- a/minc-vegu-frontend/src/App.jsx
+++ b/minc-vegu-frontend/src/App.jsx
@@ -5,6 +5,7 @@ import MinCLandingPage from "./pages/MinCLandingPage";
 import MinCLoginPage from "./pages/MinCLoginPage";
 import MinCRegisterPage from "./pages/MinCRegisterPage";
 import MinCContactSupportPage from "./pages/MinCContactSupportPage";
+import MinCVeguInstitutionsDashboard from "./pages/MinCVEGUInstitutionsDashboard";
 
 function getSessionUser() {
   try {
@@ -56,6 +57,7 @@ function App() {
         {/* Protected routes */}
         <Route path="/dashboard" element={<RequireAuth><MinCMainDashboard /></RequireAuth>} />
         <Route path="/minc-vegu-dashboard" element={<RequireAuth><MinCVeguDashboard /></RequireAuth>} />
+        <Route path="/vegu/institutions" element={<RequireAuth><MinCVeguInstitutionsDashboard /></RequireAuth>} />
 
       </Routes>
     </Router>

--- a/minc-vegu-frontend/src/pages/MinCVEGUDashboard.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUDashboard.jsx
@@ -1,43 +1,74 @@
-// src/pages/MinCVeguDashboard.jsx v1.2
+// src/pages/MinCVeguDashboard.jsx v1.3
 
-import React, { useState } from "react";       
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "../styles/MinCVeguDashboard.css";
+import "../styles/MinCDashboard.css";                  // reuse modal styles
 import instLogo from "../assets/minc-workplaces.png";
 import userLogo from "../assets/minc-users.png";
 import responderLogo from "../assets/minc-responders.png";
-import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";   // ← add
+import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
+import { FaArrowLeft, FaSignOutAlt } from "react-icons/fa";
 
 export default function MinCVeguDashboard() {
   const nav = useNavigate();
-  const [loading, setLoading] = useState(false);   
+  const [loading, setLoading] = useState(false);
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
 
-  // Tiny helper so we can show spinner (and later prefetch)
+  // guard: if no session, bounce to login
+  useEffect(() => {
+    const u = sessionStorage.getItem("mincUser");
+    if (!u) nav("/login", { replace: true });
+  }, [nav]);
+
   const go = (path) => {
     setLoading(true);
-    setTimeout(() => nav(path), 150);            
+    setTimeout(() => nav(path), 150);
   };
 
   const kpis = [
-    { key: "institutions", label: "Institutions", count: "—", onClick: () => go("/vegu/institutions"),
-      icon: <img src={instLogo} alt="Institutions" /> },
-    { key: "users",        label: "Users",        count: "—", onClick: () => go("/vegu/users"),
-      icon: <img src={userLogo} alt="Users" /> },
+    { key: "institutions", label: "Institutions", count: "—", onClick: () => go("/vegu/institutions"), icon: <img src={instLogo} alt="Institutions" /> },
+    { key: "users",        label: "Users",        count: "—", onClick: () => go("/vegu/users"),        icon: <img src={userLogo} alt="Users" /> },
     { key: "complaints",   label: "Complaints",   count: "—", onClick: () => go("/vegu/complaints"),
       icon: (
         <svg viewBox="0 0 24 24" aria-hidden="true">
           <path d="M2 3h20v14H6l-4 4zM7 8h10M7 12h7"/>
         </svg>
       ) },
-    { key: "responders",   label: "Responders",   count: "—", onClick: () => go("/vegu/responders"),
-      icon: <img src={responderLogo} alt="Responders" /> },
+    { key: "responders",   label: "Responders",   count: "—", onClick: () => go("/vegu/responders"),   icon: <img src={responderLogo} alt="Responders" /> },
   ];
 
   return (
     <div className="vegu-page">
-      <MinCSpinnerOverlay open={loading} />     
+      <MinCSpinnerOverlay open={loading} />
 
       <div className="vegu-card">
+        {/* 🔴 Back (inside card, top-left) */}
+        <div
+          className="minc-back-container"
+          role="button"
+          tabIndex={0}
+          onClick={() => nav("/dashboard", { replace: true })}
+          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && nav("/dashboard", { replace: true })}
+          aria-label="Back to MinC Main Dashboard"
+        >
+          <FaArrowLeft className="minc-back-icon" />
+          <div className="minc-back-label">Back</div>
+        </div>
+
+        {/* 🔴 Logout (inside card, top-right) */}
+        <div
+          className="minc-logout-container"
+          role="button"
+          tabIndex={0}
+          onClick={() => setShowLogoutModal(true)}
+          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && setShowLogoutModal(true)}
+          aria-label="Logout"
+        >
+          <FaSignOutAlt className="minc-logout-icon" />
+          <div className="minc-logout-label">Logout</div>
+        </div>
+
         <h1 className="vegu-title">MinC VEGU Main Dashboard</h1>
 
         <div className="vegu-kpi-grid">
@@ -52,6 +83,37 @@ export default function MinCVeguDashboard() {
           ))}
         </div>
       </div>
+
+      {/* Confirm Logout modal (reuses .minc-modal styles) */}
+      {showLogoutModal && (
+        <div className="minc-modal-backdrop" onClick={() => setShowLogoutModal(false)}>
+          <div
+            className="minc-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="logout-modal-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="logout-modal-title" className="minc-modal-title">Confirm Logout</h3>
+            <p className="minc-modal-text">Are you sure you want to logout?</p>
+            <div className="minc-modal-actions">
+              <button
+                className="btn btn-danger"
+                onClick={() => {
+                  sessionStorage.clear();
+                  setLoading(true);
+                  nav("/login", { replace: true });
+                }}
+              >
+                Yes, Logout
+              </button>
+              <button className="btn btn-secondary" onClick={() => setShowLogoutModal(false)}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/minc-vegu-frontend/src/pages/MinCVEGUInstitutionUpdate.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUInstitutionUpdate.jsx
@@ -1,9 +1,4 @@
 // src/pages/MinCVEGUInstitutionUpdate.jsx  v1.3
-// - No Logout on this screen
-// - Keyword search by name or VG ID (typeahead) + direct ID lookup
-// - Uses MinC backend endpoints (to be added next):
-//     GET  /api/vegu-institutions/{id}
-//     GET  /api/vegu-institutions/search?q=<text>
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -13,40 +8,90 @@ import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
 import { FaArrowLeft, FaSearch } from "react-icons/fa";
 import { CONFIG } from "../utils/config";
 
-
 const debugFetch = async (label, url, init = {}) => {
   console.log(`➡️ ${label} REQ`, url, init);
   const res = await fetch(url, init);
   const text = await res.text();
   console.log(`⬅️ ${label} RESP ${res.status}`, text);
-  let json; try { json = JSON.parse(text); } catch { json = { parseError: true, text }; }
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    json = { parseError: true, text };
+  }
   return { res, json };
+};
+
+// --- dropdown vocab ---
+const STATUS_OPTIONS = ["active","pending","locked","expired","suspended","paymentdue"];
+const PLAN_OPTIONS   = ["free","paid","school district","enterprise","other"];
+
+// NOTE: institution_type values in DB can be "Education"/"Educational Institution"
+// or "Company"/"Company/Workplace". We handle both.
+const EDUCATIONAL_INSTITUTION_CATEGORY_OPTIONS = [
+  "School","College","University","Community College","Training Institution","Other"
+];
+const WORKPLACE_INSTITUTION_CATEGORY_OPTIONS = [
+  "Consulting Services","Financial Services","Healthcare","Legal Services","Manufacturing","Retail","Technology","Other"
+];
+
+// --- FE rule: what is editable on this screen ---
+const EDITABLE_FIELDS = new Set([
+  "status","plan_type","institution_category",
+  "address1","address2","city","state","postal_code",
+  "complaint_phone",
+  "primary_contact_name","primary_contact_phone","primary_contact_email",
+  "website_url","comment"
+  // NOTE: country not editable (partition key), complaint_email not editable, name not editable, institution_type read-only
+]);
+
+const OTHER_PREFIX = "Other - ";
+function splitOtherCategory(raw) {
+  const s = raw || "";
+  if (s.startsWith(OTHER_PREFIX)) {
+    return { base: "Other", detail: s.slice(OTHER_PREFIX.length) };
+  }
+  return { base: s, detail: "" };
+}
+function joinOtherCategory(base, detail) {
+  if ((base || "").toLowerCase() === "other") {
+    const d = (detail || "").trim();
+    return d ? `${OTHER_PREFIX}${d}` : "Other";
+  }
+  return base || "";
+}
+
+const formatNowLocal = () => {
+  const parts = new Intl.DateTimeFormat(undefined, {
+    year:"numeric",month:"2-digit",day:"2-digit",
+    hour:"2-digit",minute:"2-digit",second:"2-digit",
+    hour12:false,timeZoneName:"short"
+  }).formatToParts(new Date());
+  const get = (t) => parts.find(p=>p.type===t)?.value || "";
+  return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}:${get("second")} ${get("timeZoneName")}`;
+};
+
+const getSessionUserLabel = () => {
+  try {
+    const raw = sessionStorage.getItem("mincUser");
+    const u = raw ? JSON.parse(raw) : null;
+    return (u?.displayName || u?.mincId || "MinC Admin");
+  } catch { return "MinC Admin"; }
 };
 
 // ---- local time formatter (YYYY-MM-DD HH:mm:ss TZ) ----
 function formatLocalTs(input) {
-  // allow 0; treat null/undefined/"" as empty
   if (input === null || input === undefined || input === "") return "—";
-
   let d;
   try {
-    // Cosmos _ts is epoch seconds; updated_at is ISO
     if (typeof input === "number") d = new Date(input * 1000);
     else d = new Date(input);
-
     if (Number.isNaN(d.getTime())) return String(input);
-
     const parts = new Intl.DateTimeFormat(undefined, {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
-      timeZoneName: "short",
+      year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", second: "2-digit",
+      hour12: false, timeZoneName: "short",
     }).formatToParts(d);
-
     const get = (t) => parts.find((p) => p.type === t)?.value || "";
     return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}:${get("second")} ${get("timeZoneName")}`;
   } catch {
@@ -69,6 +114,7 @@ export default function MinCVEGUInstitutionUpdate() {
   const nav = useNavigate();
   const [loading, setLoading] = useState(false);
   const [selectedIdx, setSelectedIdx] = useState(-1);
+  const [showNotesFull, setShowNotesFull] = useState(false);
 
   const [instId, setInstId] = useState(""); // text in the input (can be ID or keyword)
   const [etag, setEtag] = useState("");
@@ -80,11 +126,31 @@ export default function MinCVEGUInstitutionUpdate() {
   const [searching, setSearching] = useState(false);
   const searchAbortRef = useRef(null);
 
+  // edit mode state
+  const [editMode, setEditMode] = useState(false);
+  const [draft, setDraft] = useState(null);
+  const [newNote, setNewNote] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState("");
+
+  // NEW: discard confirm
+  const [showDiscard, setShowDiscard] = useState(false);
+
+  const notesPreview = (txt = "") =>
+  txt.trim().split("\n").slice(-3).join("\n"); // last 3 lines
+
   // session guard
   useEffect(() => {
     const u = sessionStorage.getItem("mincUser");
     if (!u) nav("/login", { replace: true });
   }, [nav]);
+
+useEffect(() => {
+  if (!showDiscard) return;
+  const onKey = (e) => e.key === "Escape" && setShowDiscard(false);
+  window.addEventListener("keydown", onKey);
+  return () => window.removeEventListener("keydown", onKey);
+}, [showDiscard]);
 
   const isLikelyId = useMemo(() => /^VG\d{5,}$/.test(instId.trim()), [instId]);
 
@@ -92,11 +158,8 @@ export default function MinCVEGUInstitutionUpdate() {
   useEffect(() => {
     const q = instId.trim();
     setResults([]);
-
-    // only search when not a clear full-id and query has some length
     if (!q || isLikelyId) return;
 
-    // debounce 250ms
     const t = setTimeout(async () => {
       try {
         if (searchAbortRef.current) searchAbortRef.current.abort();
@@ -105,16 +168,11 @@ export default function MinCVEGUInstitutionUpdate() {
 
         setSearching(true);
         const url = makeUrl(CONFIG.PATHS.VEGU_INST_SEARCH, `?q=${encodeURIComponent(q)}`);
-        const res = await fetch(url, { method: "GET", signal: ctrl.signal });
-        const text = await res.text();
-        let json;
-        try { json = JSON.parse(text); } catch { throw new Error(`Non-JSON response (${res.status}): ${text}`); }
-
+        const { res, json } = await debugFetch("vegu-institutions-search(typeahead)", url, { method: "GET", signal: ctrl.signal });
         if (!res.ok || json.success !== true) {
           setResults([]);
           return;
         }
-        // Expect: { success: true, items: [ ... ] }
         setResults(Array.isArray(json.items) ? json.items.slice(0, 10) : []);
       } catch (e) {
         if (e.name !== "AbortError") console.error(e);
@@ -125,29 +183,37 @@ export default function MinCVEGUInstitutionUpdate() {
     return () => clearTimeout(t);
   }, [instId, isLikelyId]);
 
+  const seedDraftFromDoc = (doc) => {
+    const { base, detail } = splitOtherCategory(doc.institution_category);
+    setDraft({ ...doc, _cat_base: base, _cat_detail: detail });
+  };
+
   const lookupById = async (id) => {
     setError("");
     setInst(null);
     setEtag("");
     setLoading(true);
     try {
-    // Preferred: dedicated GET by ID (to be implemented)
-    const urlGet = makeUrl(`${CONFIG.PATHS.VEGU_INST_GET}/${encodeURIComponent(id)}`);
-    let { res, json } = await debugFetch("vegu-institutions-get", urlGet);
-    if (res.ok && json && json.success && json.institution) {
-      setInst(json.institution);
-      setEtag(json.etag || "");
-      return;
-    }
-    // Fallback: search by q=id and take first match (works today)
-    const urlSearch = makeUrl(CONFIG.PATHS.VEGU_INST_SEARCH, `?q=${encodeURIComponent(id)}`);
-    ({ res, json } = await debugFetch("vegu-institutions-search(fallback)", urlSearch));
-    if (res.ok && json && json.success && Array.isArray(json.items) && json.items.length) {
-      setInst(json.items[0]);
-      setEtag(json.etag || "");
-      return;
-    }
-    setError((json && json.error) || "Institution not found.");
+      // Preferred: dedicated GET by ID
+      const urlGet = makeUrl(`${CONFIG.PATHS.VEGU_INST_GET}/${encodeURIComponent(id)}`);
+      let { res, json } = await debugFetch("vegu-institutions-get", urlGet);
+      if (res.ok && json && json.success && json.institution) {
+        setInst(json.institution || null);
+        seedDraftFromDoc(json.institution);
+        setEtag(json.etag || "");
+        return;
+      }
+      // Fallback: search by q=id and take first match
+      const urlSearch = makeUrl(CONFIG.PATHS.VEGU_INST_SEARCH, `?q=${encodeURIComponent(id)}`);
+      ({ res, json } = await debugFetch("vegu-institutions-search(fallback)", urlSearch));
+      if (res.ok && json && json.success && Array.isArray(json.items) && json.items.length) {
+        const item = json.items[0];
+        setInst(item);
+        setEtag(json.etag || "");
+        seedDraftFromDoc(item);
+        return;
+      }
+      setError((json && json.error) || "Institution not found.");
     } catch (err) {
       console.error(err);
       setError(err.message || "Network error during lookup.");
@@ -157,49 +223,152 @@ export default function MinCVEGUInstitutionUpdate() {
   };
 
   const handleSubmit = async (e) => {
-  e?.preventDefault?.();
-  const q = instId.trim();
-  setError("");
+    e?.preventDefault?.();
+    const q = instId.trim();
+    setError("");
 
-  if (!q) {
-    setError("Please enter an Institution ID or keywords.");
-    return;
-  }
-
-  if (isLikelyId) {
-    await lookupById(q);
-    return;
-  }
-
-  // If we already have results (from typeahead), use them.
-  let list = results;
-  if (!list || list.length === 0) {
-    // Fallback: do a synchronous search now
-    try {
-      setSearching(true);
-    const url = makeUrl(CONFIG.PATHS.VEGU_INST_SEARCH, `?q=${encodeURIComponent(q)}`);
-    const { res, json } = await debugFetch("vegu-institutions-search", url);
-
-      if (res.ok && json.success === true) list = json.items || [];
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setSearching(false);
+    if (!q) {
+      setError("Please enter an Institution ID or keywords.");
+      return;
     }
-  }
+    if (isLikelyId) {
+      await lookupById(q);
+      return;
+    }
 
-  if (list && list.length > 0) {
-    await lookupById(list[0].vg_id || list[0].id);
-  } else {
-    setError("No matches. Try different keywords or a full VG ID.");
-  }
-};
+    let list = results;
+    if (!list || list.length === 0) {
+      try {
+        setSearching(true);
+        const url = makeUrl(CONFIG.PATHS.VEGU_INST_SEARCH, `?q=${encodeURIComponent(q)}`);
+        const { res, json } = await debugFetch("vegu-institutions-search", url);
+        if (res.ok && json.success === true) list = json.items || [];
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setSearching(false);
+      }
+    }
+    if (list && list.length > 0) {
+      await lookupById(list[0].vg_id || list[0].id);
+    } else {
+      setError("No matches. Try different keywords or a full VG ID.");
+    }
+  };
 
   const pickResult = async (r) => {
     const id = r.vg_id || r.id;
     setInstId(id);
     await lookupById(id);
     setResults([]);
+  };
+
+  const updateDraft = (field, value) => {
+    setDraft(d => ({ ...(d || {}), [field]: value }));
+  };
+
+  // reverse-chronology admin notes (newest first)
+const notesDesc = React.useMemo(() => {
+  const s = inst?.admin_notes || "";
+  return s
+    .split("\n")
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .reverse();
+}, [inst?.admin_notes]);
+
+  // category options based on (read-only) institution_type
+  const typeKey = (inst?.institution_type || "").toLowerCase();
+  const isEdu = typeKey.startsWith("education");  // "Education" or "Educational Institution"
+  const isCompany = typeKey.startsWith("company");
+  const categoryOptions = isEdu
+    ? EDUCATIONAL_INSTITUTION_CATEGORY_OPTIONS
+    : (isCompany ? WORKPLACE_INSTITUTION_CATEGORY_OPTIONS : []);
+
+  // plan/category detail toggles
+  const needsPlanDetail = (draft?.plan_type || "").toLowerCase() === "other";
+  const needsCatDetail  = (draft?._cat_base || "").toLowerCase() === "other";
+
+  // build patch (only changed & editable)
+  const buildPatch = () => {
+    if (!inst || !draft) return {};
+    const p = {};
+
+    for (const k of EDITABLE_FIELDS) {
+      if (k === "institution_category") continue; // handled below
+      if (draft[k] !== inst[k]) p[k] = draft[k];
+    }
+
+    // Plan: fold detail when "other"
+    if ((draft?.plan_type || "").toLowerCase() === "other" && draft._plan_detail?.trim()) {
+      p.plan_type = `Other - ${draft._plan_detail.trim()}`;
+    }
+
+    // Category: recompose from base/detail, then diff vs original
+    const recomposed = joinOtherCategory(draft._cat_base, draft._cat_detail);
+    if (recomposed !== (inst.institution_category || "")) {
+      p.institution_category = recomposed;
+    }
+
+    return p;
+  };
+
+  const hasUnsavedChanges = () => {
+  const p = buildPatch();
+  // note text itself shouldn't block cancel if no field changed
+  return Object.keys(p).length > 0;
+  };
+
+  const handleSave = async () => {
+    setSaveError("");
+    const patch = buildPatch();
+    const hasChanges = Object.keys(patch).length > 0;
+
+    if (!hasChanges) { setEditMode(false); return; }
+
+    if (!newNote.trim()) {
+      setSaveError("Admin note is required to save changes.");
+      return;
+    }
+
+    const stamp = `[${formatNowLocal()}] ${getSessionUserLabel()}: ${newNote.trim()}`;
+    const mergedNotes = (inst.admin_notes ? `${inst.admin_notes}\n` : "") + stamp;
+    patch.admin_notes = mergedNotes;
+
+    setSaving(true);
+    try {
+      const url = makeUrl(CONFIG.PATHS.VEGU_INST_UPDATE);
+      const { res, json } = await debugFetch("vegu-institutions-update", url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ vg_id: inst.vg_id, etag, patch })
+      });
+
+      if (res.status === 409 && json?.error === "etag_mismatch") {
+        setSaveError("This record was modified by someone else. Please refresh and retry.");
+        if (json.etag) {
+          await lookupById(inst.vg_id); // refresh with latest
+          setEditMode(true);
+        }
+        return;
+      }
+
+      if (!res.ok || !json?.success) {
+        setSaveError(json?.error || `Save failed (${res.status}).`);
+        return;
+      }
+
+      setInst(json.institution);
+      seedDraftFromDoc(json.institution);
+      setEtag(json.etag || "");
+      setNewNote("");
+      setEditMode(false);
+    } catch (e) {
+      console.error(e);
+      setSaveError(e.message || "Network error while saving.");
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -234,40 +403,27 @@ export default function MinCVEGUInstitutionUpdate() {
             position: "relative",
           }}
         >
-
           <input
-  type="text"
-  value={instId}
-  onChange={(e) => {
-    setInstId(e.target.value);
-    setSelectedIdx(-1); // reset selection on text change
-  }}
-  onKeyDown={(e) => {
-    if (isLikelyId || results.length === 0) return;
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      setSelectedIdx((i) => Math.min(i + 1, results.length - 1));
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      setSelectedIdx((i) => Math.max(i - 1, 0));
-    } else if (e.key === "Enter") {
-      if (selectedIdx >= 0) {
-        e.preventDefault();
-        pickResult(results[selectedIdx]);
-      }
-    }
-  }}
-  placeholder="Enter Institution ID (e.g., VG25001055) or keywords…"
-  aria-label="Institution ID or search keywords"
-  autoFocus
-  style={{
-    padding: "12px 14px",
-    borderRadius: 12,
-    border: "2px solid #9aa5b1",
-    fontFamily: "'Exo 2', sans-serif",
-    fontSize: "1rem",
-  }}
-/>
+            type="text"
+            value={instId}
+            onChange={(e) => { setInstId(e.target.value); setSelectedIdx(-1); }}
+            onKeyDown={(e) => {
+              if (isLikelyId || results.length === 0) return;
+              if (e.key === "ArrowDown") { e.preventDefault(); setSelectedIdx((i) => Math.min(i + 1, results.length - 1)); }
+              else if (e.key === "ArrowUp") { e.preventDefault(); setSelectedIdx((i) => Math.max(i - 1, 0)); }
+              else if (e.key === "Enter" && selectedIdx >= 0) { e.preventDefault(); pickResult(results[selectedIdx]); }
+            }}
+            placeholder="Enter Institution ID (e.g., VG25001055) or keywords…"
+            aria-label="Institution ID or search keywords"
+            autoFocus
+            style={{
+              padding: "12px 14px",
+              borderRadius: 12,
+              border: "2px solid #9aa5b1",
+              fontFamily: "'Exo 2', sans-serif",
+              fontSize: "1rem",
+            }}
+          />
 
           <button
             type="submit"
@@ -314,36 +470,35 @@ export default function MinCVEGUInstitutionUpdate() {
               )}
 
               {results.map((r, idx) => (
-  <button
-    key={r.id || r.vg_id}
-    type="button"
-    onClick={() => pickResult(r)}
-    aria-selected={idx === selectedIdx}
-    style={{
-      display: "grid",
-      gridTemplateColumns: "auto 1fr auto",
-      gap: 10,
-      width: "100%",
-      textAlign: "left",
-      padding: "10px 12px",
-      border: 0,
-      cursor: "pointer",
-      background: idx === selectedIdx ? "#fffef2" : "transparent"
-    }}
-  >
-    <span style={{ opacity: 0.85 }}>🏢</span>
-    <span style={{ color: "#1B5228", fontWeight: 700 }}>
-      {r.name || "—"}
-      <span style={{ color: "#64748b", fontWeight: 500 }}>
-        {" "}— {r.city || "—"}, {r.country || "—"}
-      </span>
-    </span>
-    <span style={{ fontFamily: "Orbitron, sans-serif", color: "#234a39" }}>
-      {r.vg_id || r.id}
-    </span>
-  </button>
-))}
-
+                <button
+                  key={r.id || r.vg_id}
+                  type="button"
+                  onClick={() => pickResult(r)}
+                  aria-selected={idx === selectedIdx}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "auto 1fr auto",
+                    gap: 10,
+                    width: "100%",
+                    textAlign: "left",
+                    padding: "10px 12px",
+                    border: 0,
+                    cursor: "pointer",
+                    background: idx === selectedIdx ? "#fffef2" : "transparent"
+                  }}
+                >
+                  <span style={{ opacity: 0.85 }}>🏢</span>
+                  <span style={{ color: "#1B5228", fontWeight: 700 }}>
+                    {r.name || "—"}
+                    <span style={{ color: "#64748b", fontWeight: 500 }}>
+                      {" "}— {r.city || "—"}, {r.country || "—"}
+                    </span>
+                  </span>
+                  <span style={{ fontFamily: "Orbitron, sans-serif", color: "#234a39" }}>
+                    {r.vg_id || r.id}
+                  </span>
+                </button>
+              ))}
             </div>
           )}
         </form>
@@ -367,7 +522,7 @@ export default function MinCVEGUInstitutionUpdate() {
           </div>
         )}
 
-        {/* Result (read-only preview for now) */}
+        {/* Result */}
         {inst && (
           <div
             style={{
@@ -387,68 +542,329 @@ export default function MinCVEGUInstitutionUpdate() {
                 gap: 12,
               }}
             >
-              <Field label="Name" value={inst.name} />
-<Field label="VG ID" value={inst.vg_id} />
-<Field label="Status" value={inst.status} />
-<Field label="Plan" value={inst.plan_type} />
-<Field label="Institution Type" value={inst.institution_type} />
-<Field label="Institution Category" value={inst.institution_category} />
-<Field label="Address1" value={inst.address1} />
-<Field label="Address2" value={inst.address2} />
-<Field label="Comment" value={inst.comment} />
-<Field label="Admin Notes" value={inst.admin_notes} />
-<Field label="Country" value={inst.country} />
-<Field label="Complaint Phone" value={inst.complaint_phone} />
-<Field label="City" value={inst.city} />
-<Field label="State" value={inst.state} />
-<Field label="Complaint Email" value={inst.complaint_email} />
-<Field label="Primary Contact Name" value={inst.primary_contact_name} />
-<Field label="Primary Contact Phone" value={inst.primary_contact_phone} />
-<Field label="Primary Contact Email" value={inst.primary_contact_Email} />
-<Field label="Website" value={inst.website_url} />
-<Field label="Updated At" value={formatLocalTs(inst.updated_at ?? inst._ts)} />
+              {/* Non-editable on this screen */}
+              <Field label="Name" value={inst.name} readOnly={editMode} />
+              <Field label="VG ID" value={inst.vg_id} readOnly={editMode} />
+              <Field label="Country" value={inst.country} readOnly={editMode} />
+              <Field label="Complaint Email" value={inst.complaint_email} readOnly={editMode} />
+
+              {/* Editable dropdowns */}
+              <RWSelect
+                edit={editMode}
+                label="Status"
+                value={draft?.status ?? inst?.status ?? ""}
+                onChange={(v)=>updateDraft("status", v)}
+                options={STATUS_OPTIONS}
+              />
+              <RWSelect
+                edit={editMode}
+                label="Plan"
+                value={draft?.plan_type ?? inst?.plan_type ?? ""}
+                onChange={(v)=>updateDraft("plan_type", v)}
+                options={PLAN_OPTIONS}
+              />
+              {editMode && needsPlanDetail && (
+                <InputRow
+                  label="Plan detail (when Other)"
+                  value={draft?._plan_detail || ""}
+                  onChange={(v)=>updateDraft("_plan_detail", v)}
+                  placeholder="e.g., Free for 3 months"
+                />
+              )}
+
+              {/* Institution Type — read-only in edit mode */}
+              <Field label="Institution Type" value={inst?.institution_type || "—"} readOnly={editMode} />
+
+              {/* Institution Category — context-aware + Other detail */}
+              {!editMode ? (
+                <Field label="Institution Category" value={inst.institution_category} />
+              ) : (
+                <>
+                  <SelectRow
+                    label="Institution Category"
+                    value={draft?._cat_base || ""}
+                    onChange={(v)=>{ updateDraft("_cat_base", v); if (v !== "Other") updateDraft("_cat_detail", ""); }}
+                    options={categoryOptions}
+                  />
+                  {(draft?._cat_base || "").toLowerCase() === "other" && (
+                    <InputRow
+                      label="Please specify"
+                      value={draft?._cat_detail || ""}
+                      onChange={(v)=>updateDraft("_cat_detail", v)}
+                      placeholder="e.g., Online University"
+                    />
+                  )}
+                </>
+              )}
+
+              {/* text inputs */}
+              <RWField edit={editMode} label="Address1" value={draft?.address1 || ""} onChange={(v)=>updateDraft("address1", v)} />
+              <RWField edit={editMode} label="Address2" value={draft?.address2 || ""} onChange={(v)=>updateDraft("address2", v)} />
+              <RWField edit={editMode} label="City" value={draft?.city || ""} onChange={(v)=>updateDraft("city", v)} />
+              <RWField edit={editMode} label="State" value={draft?.state || ""} onChange={(v)=>updateDraft("state", v)} />
+              <RWField edit={editMode} label="Postal Code" value={draft?.postal_code || ""} onChange={(v)=>updateDraft("postal_code", v)} />
+              <RWField edit={editMode} label="Complaint Phone" value={draft?.complaint_phone || ""} onChange={(v)=>updateDraft("complaint_phone", v)} />
+              <RWField edit={editMode} label="Primary Contact Name" value={draft?.primary_contact_name || ""} onChange={(v)=>updateDraft("primary_contact_name", v)} />
+              <RWField edit={editMode} label="Primary Contact Phone" value={draft?.primary_contact_phone || ""} onChange={(v)=>updateDraft("primary_contact_phone", v)} />
+              <RWField edit={editMode} label="Primary Contact Email" value={draft?.primary_contact_email || ""} onChange={(v)=>updateDraft("primary_contact_email", v)} />
+              <RWField edit={editMode} label="Website" value={draft?.website_url || ""} onChange={(v)=>updateDraft("website_url", v)} />
+              <RWTextArea edit={editMode} label="Institution Comments" value={draft?.comment || ""} onChange={(v)=>updateDraft("comment", v)} rows={2} />
+
+              {/* read-only */}
+              <Field label="Updated At" value={formatLocalTs(inst.updated_at ?? inst._ts)} />
             </div>
 
-            <div style={{ textAlign: "right", marginTop: 12 }}>
-              <button
-                type="button"
-                className="btn"
-                onClick={() => alert("Edit form will be added next.")}
-                style={{
-                  padding: "10px 16px",
-                  borderRadius: 10,
-                  border: "2px solid #F1663D",
-                  background: "#F5EE1F",
-                  color: "#1B5228",
-                  fontWeight: 800,
-                }}
-              >
-                Edit…
-              </button>
+            {/* Read-only Admin Notes in view mode */}
+{!editMode && inst?.admin_notes && (
+  <div
+    style={{
+      marginTop: 12,
+      background: "#fff",
+      border: "1px solid #cbd5e1",
+      borderRadius: 10,
+      padding: "10px 12px",
+    }}
+  >
+    <div style={{ fontSize: 12, color: "#475569", marginBottom: 4 }}>
+      Admin Notes
+    </div>
+    <pre
+      style={{
+        margin: 0,
+        whiteSpace: "pre-wrap",
+        fontFamily: "inherit",
+        color: "#1B5228",
+      }}
+    >
+      {inst.admin_notes
+        .trim()
+        .split("\n")
+        .filter(Boolean)            // drop empty lines
+        .reverse()                  // newest first
+        .join("\n")}
+    </pre>
+  </div>
+)}
+
+            {/* Admin Notes entry (only in edit mode) */}
+            {editMode && (
+              <>
+{notesDesc.length > 0 && (
+  <div style={{ background:"#fff", border:"1px solid #cbd5e1", borderRadius:10, padding:"10px 12px", marginTop:12 }}>
+    <div style={{ fontSize:12, color:"#475569", marginBottom:4 }}>Existing Admin Notes</div>
+    <pre style={{ margin:0, whiteSpace:"pre-wrap", fontFamily:"inherit", color:"#1B5228" }}>
+      {notesDesc.join("\n")}
+    </pre>
+  </div>
+)}
+                <TextAreaRow
+                  label="New Admin Note (required to save changes)"
+                  value={newNote}
+                  onChange={setNewNote}
+                  placeholder="Brief reason for the change…"
+                  rows={3}
+                  required
+                />
+              </>
+            )}
+
+            {/* Actions */}
+            <div style={{ textAlign: "right", marginTop: 12, display:"flex", gap:10, justifyContent:"flex-end" }}>
+              {!editMode ? (
+                <button
+                  type="button"
+                  className="btn"
+                  onClick={() => { setEditMode(true); seedDraftFromDoc(inst); setSaveError(""); }}
+                  style={{ padding:"10px 16px", borderRadius:10, border:"2px solid #F1663D", background:"#F5EE1F", color:"#1B5228", fontWeight:800 }}
+                >
+                  Update…
+                </button>
+              ) : (
+                <>
+<button
+  type="button"
+  className="btn"
+  onClick={() => {
+    if (hasUnsavedChanges() || newNote.trim()) {
+      setShowDiscard(true);               // <-- open dialog
+    } else {
+      setEditMode(false);                 // nothing to lose; just exit
+      setDraft(inst ? { ...inst } : null);
+      setNewNote("");
+      setSaveError("");
+    }
+  }}
+  style={{ padding:"10px 16px", borderRadius:10, border:"2px solid #cbd5e1", background:"#fff", color:"#334155", fontWeight:700 }}
+  disabled={saving}
+>
+  Cancel
+</button>
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={handleSave}
+                    style={{ padding:"10px 16px", borderRadius:10, border:"2px solid #F1663D", background:"#F5EE1F", color:"#1B5228", fontWeight:800 }}
+                    disabled={saving}
+                  >
+                    {saving ? "Saving…" : "Save Changes"}
+                  </button>
+                </>
+              )}
             </div>
+
+            {/* Save error */}
+            {saveError && (
+              <div role="alert" style={{ marginTop:10, background:"#fff6f6", border:"2px solid #f3b8b8", color:"#7a1d1d", borderRadius:12, padding:"10px 12px", fontFamily:"'Exo 2', sans-serif" }}>
+                {saveError}
+              </div>
+            )}
           </div>
         )}
+      </div>
+      {showDiscard && (
+  <div
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="discard-title"
+    onClick={(e) => {
+      // close only on backdrop click
+      if (e.target === e.currentTarget) setShowDiscard(false);
+    }}
+    style={{
+      position: "fixed", inset: 0, background: "rgba(0,0,0,.35)",
+      display: "grid", placeItems: "center", zIndex: 1000
+    }}
+  >
+    <div
+      style={{
+        background: "white", borderRadius: 14, padding: 18, maxWidth: 520, width: "92%",
+        boxShadow: "0 14px 40px rgba(0,0,0,.25)", border: "2px solid #cbd5e1"
+      }}
+    >
+      <div id="discard-title" style={{ fontWeight: 800, color: "#1B5228", marginBottom: 8 }}>
+        Discard changes?
+      </div>
+      <div style={{ color: "#334155", marginBottom: 14 }}>
+        You have unsaved edits. If you leave now, your changes will be lost.
+      </div>
+      <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
+        <button
+          type="button"
+          onClick={() => setShowDiscard(false)}
+          className="btn"
+          style={{ padding:"10px 16px", borderRadius:10, border:"2px solid #cbd5e1", background:"#fff", color:"#334155", fontWeight:700 }}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setShowDiscard(false);
+            setEditMode(false);
+            setDraft(inst ? { ...inst } : null);
+            setNewNote("");
+            setSaveError("");
+          }}
+          className="btn"
+          style={{ padding:"10px 16px", borderRadius:10, border:"2px solid #F1663D", background:"#F5EE1F", color:"#1B5228", fontWeight:800 }}
+        >
+          Discard Changes
+        </button>
+      </div>
+    </div>
+  </div>
+)}
+    </div>
+  );
+}
+
+function Field({ label, value, readOnly = false }) {
+  const base = {
+    background: "white",
+    border: "1px solid #cbd5e1",
+    borderRadius: 10,
+    padding: "10px 12px",
+    minHeight: 52,
+  };
+  const ro = readOnly ? {
+    background: "#f7fafc",
+    border: "1px dashed #cbd5e1",
+  } : {};
+  return (
+    <div style={{ ...base, ...ro }} aria-readonly={readOnly ? "true" : undefined}>
+      <div style={{ fontSize: 12, color: readOnly ? "#718096" : "#475569", marginBottom: 4, display:"flex", gap:6, alignItems:"center" }}>
+        {readOnly && <span aria-hidden="true">🔒</span>}
+        {label}
+      </div>
+      <div style={{ color: readOnly ? "#2f855a" : "#1B5228", fontWeight: 700, wordBreak: "break-word" }}>
+        {value ?? "—"}
       </div>
     </div>
   );
 }
 
-function Field({ label, value }) {
+function InputRow({ label, value, onChange, placeholder="" }) {
   return (
-    <div
-      style={{
-        background: "white",
-        border: "1px solid #cbd5e1",
-        borderRadius: 10,
-        padding: "10px 12px",
-        minHeight: 52,
-      }}
-    >
-      <div style={{ fontSize: 12, color: "#475569", marginBottom: 4 }}>{label}</div>
-      <div style={{ color: "#1B5228", fontWeight: 700, wordBreak: "break-word" }}>
-        {value ?? "—"}
-      </div>
+    <div style={{ background:"#fff", border:"1px solid #cbd5e1", borderRadius:10, padding:"10px 12px" }}>
+      <div style={{ fontSize:12, color:"#475569", marginBottom:4 }}>{label}</div>
+      <input
+        value={value || ""}
+        onChange={(e)=>onChange(e.target.value)}
+        placeholder={placeholder}
+        style={{ width:"100%", border:"1px solid #cbd5e1", borderRadius:8, padding:"8px 10px", fontFamily:"'Exo 2', sans-serif" }}
+      />
     </div>
   );
+}
 
+function TextAreaRow({ label, value, onChange, rows=3, required=false, placeholder="" }) {
+  return (
+    <div style={{ background:"#fff", border:"1px solid #cbd5e1", borderRadius:10, padding:"10px 12px" }}>
+      <div style={{ fontSize:12, color:"#475569", marginBottom:4 }}>
+        {label}{required ? " *" : ""}
+      </div>
+      <textarea
+        value={value || ""}
+        onChange={(e)=>onChange(e.target.value)}
+        rows={rows}
+        placeholder={placeholder}
+        style={{ width:"100%", border:"1px solid #cbd5e1", borderRadius:8, padding:"8px 10px", fontFamily:"'Exo 2', sans-serif", resize:"vertical" }}
+      />
+    </div>
+  );
+}
+
+function SelectRow({ label, value, onChange, options=[] }) {
+  return (
+    <div style={{ background:"#fff", border:"1px solid #cbd5e1", borderRadius:10, padding:"10px 12px" }}>
+      <div style={{ fontSize:12, color:"#475569", marginBottom:4 }}>{label}</div>
+      <select
+        value={value || ""}
+        onChange={(e)=>onChange(e.target.value)}
+        style={{ width:"100%", border:"1px solid #cbd5e1", borderRadius:8, padding:"8px 10px", fontFamily:"'Exo 2', sans-serif" }}
+      >
+        <option value="">— Select —</option>
+        {options.map(opt => (<option key={opt} value={opt}>{opt}</option>))}
+      </select>
+    </div>
+  );
+}
+
+// read/write versions of a field
+function RWField({ edit, label, value, onChange, placeholder }) {
+  return edit
+    ? <InputRow label={label} value={value} onChange={onChange} placeholder={placeholder} />
+    : <Field label={label} value={value} />;
+}
+
+function RWSelect({ edit, label, value, onChange, options }) {
+  return edit
+    ? <SelectRow label={label} value={value} onChange={onChange} options={options} />
+    : <Field label={label} value={value} />;
+}
+
+function RWTextArea({ edit, label, value, onChange, rows=3, required=false, placeholder }) {
+  return edit
+    ? <TextAreaRow label={label} value={value} onChange={onChange} rows={rows} required={required} placeholder={placeholder} />
+    : <Field label={label} value={value} />;
 }

--- a/minc-vegu-frontend/src/pages/MinCVEGUInstitutionUpdate.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUInstitutionUpdate.jsx
@@ -11,10 +11,59 @@ import "../styles/MinCVeguDashboard.css";
 import "../styles/MinCDashboard.css";
 import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
 import { FaArrowLeft, FaSearch } from "react-icons/fa";
+import { CONFIG } from "../utils/config";
 
-// Adjust to your config setup
-const BASE_URL = import.meta.env.VITE_MINC_API_BASE || "";
-const REACT_FUNCTION_KEY = window.mincFunctionKey || "";
+
+const debugFetch = async (label, url, init = {}) => {
+  console.log(`➡️ ${label} REQ`, url, init);
+  const res = await fetch(url, init);
+  const text = await res.text();
+  console.log(`⬅️ ${label} RESP ${res.status}`, text);
+  let json; try { json = JSON.parse(text); } catch { json = { parseError: true, text }; }
+  return { res, json };
+};
+
+// ---- local time formatter (YYYY-MM-DD HH:mm:ss TZ) ----
+function formatLocalTs(input) {
+  // allow 0; treat null/undefined/"" as empty
+  if (input === null || input === undefined || input === "") return "—";
+
+  let d;
+  try {
+    // Cosmos _ts is epoch seconds; updated_at is ISO
+    if (typeof input === "number") d = new Date(input * 1000);
+    else d = new Date(input);
+
+    if (Number.isNaN(d.getTime())) return String(input);
+
+    const parts = new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+      timeZoneName: "short",
+    }).formatToParts(d);
+
+    const get = (t) => parts.find((p) => p.type === t)?.value || "";
+    return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}:${get("second")} ${get("timeZoneName")}`;
+  } catch {
+    return String(input);
+  }
+}
+
+// Build URLs consistently with the rest of the app
+const makeUrl = (path, qs = "") => {
+  const base = CONFIG.API_BASE || "";
+  const key  = CONFIG.API_KEY;
+  const sep  = qs.includes("?") ? "&" : "?";
+  const withKey = key ? `${qs}${sep}code=${encodeURIComponent(key)}` : qs || "";
+  const url = `${base}${path}${withKey}`;
+  console.debug("[MinC] calling:", url);
+  return url;
+};
 
 export default function MinCVEGUInstitutionUpdate() {
   const nav = useNavigate();
@@ -55,20 +104,17 @@ export default function MinCVEGUInstitutionUpdate() {
         searchAbortRef.current = ctrl;
 
         setSearching(true);
-        const url =
-          `${BASE_URL}/api/vegu-institutions/search?q=` +
-          encodeURIComponent(q) +
-          (REACT_FUNCTION_KEY ? `&code=${REACT_FUNCTION_KEY}` : "");
+        const url = makeUrl(CONFIG.PATHS.VEGU_INST_SEARCH, `?q=${encodeURIComponent(q)}`);
         const res = await fetch(url, { method: "GET", signal: ctrl.signal });
         const text = await res.text();
         let json;
         try { json = JSON.parse(text); } catch { throw new Error(`Non-JSON response (${res.status}): ${text}`); }
 
-        if (!res.ok || json.ok === false) {
+        if (!res.ok || json.success !== true) {
           setResults([]);
           return;
         }
-        // Expect: { ok: true, items: [ { id, vg_id, name, status, country, _etag? } ] }
+        // Expect: { success: true, items: [ ... ] }
         setResults(Array.isArray(json.items) ? json.items.slice(0, 10) : []);
       } catch (e) {
         if (e.name !== "AbortError") console.error(e);
@@ -77,7 +123,7 @@ export default function MinCVEGUInstitutionUpdate() {
       }
     }, 250);
     return () => clearTimeout(t);
-  }, [instId, isLikelyId, BASE_URL]);
+  }, [instId, isLikelyId]);
 
   const lookupById = async (id) => {
     setError("");
@@ -85,22 +131,23 @@ export default function MinCVEGUInstitutionUpdate() {
     setEtag("");
     setLoading(true);
     try {
-      const url =
-        `${BASE_URL}/api/vegu-institutions/` +
-        encodeURIComponent(id) +
-        (REACT_FUNCTION_KEY ? `?code=${REACT_FUNCTION_KEY}` : "");
-      const res = await fetch(url, { method: "GET" });
-      const text = await res.text();
-      let json;
-      try { json = JSON.parse(text); } catch { throw new Error(`Non-JSON response (${res.status}): ${text}`); }
-
-      if (!res.ok || json.ok === false) {
-        setError(json.error || `Lookup failed (${res.status})`);
-        return;
-      }
-
-      setInst(json.institution || null);
+    // Preferred: dedicated GET by ID (to be implemented)
+    const urlGet = makeUrl(`${CONFIG.PATHS.VEGU_INST_GET}/${encodeURIComponent(id)}`);
+    let { res, json } = await debugFetch("vegu-institutions-get", urlGet);
+    if (res.ok && json && json.success && json.institution) {
+      setInst(json.institution);
       setEtag(json.etag || "");
+      return;
+    }
+    // Fallback: search by q=id and take first match (works today)
+    const urlSearch = makeUrl(CONFIG.PATHS.VEGU_INST_SEARCH, `?q=${encodeURIComponent(id)}`);
+    ({ res, json } = await debugFetch("vegu-institutions-search(fallback)", urlSearch));
+    if (res.ok && json && json.success && Array.isArray(json.items) && json.items.length) {
+      setInst(json.items[0]);
+      setEtag(json.etag || "");
+      return;
+    }
+    setError((json && json.error) || "Institution not found.");
     } catch (err) {
       console.error(err);
       setError(err.message || "Network error during lookup.");
@@ -110,21 +157,43 @@ export default function MinCVEGUInstitutionUpdate() {
   };
 
   const handleSubmit = async (e) => {
-    e?.preventDefault?.();
-    const q = instId.trim();
-    if (!q) { setError("Please enter an Institution ID or keywords."); return; }
-    if (isLikelyId) {
-      await lookupById(q);
-    } else if (results.length === 1) {
-      await lookupById(results[0].vg_id || results[0].id);
-    } else {
-  if (results.length > 0) {
-    await lookupById(results[0].vg_id || results[0].id);
+  e?.preventDefault?.();
+  const q = instId.trim();
+  setError("");
+
+  if (!q) {
+    setError("Please enter an Institution ID or keywords.");
+    return;
+  }
+
+  if (isLikelyId) {
+    await lookupById(q);
+    return;
+  }
+
+  // If we already have results (from typeahead), use them.
+  let list = results;
+  if (!list || list.length === 0) {
+    // Fallback: do a synchronous search now
+    try {
+      setSearching(true);
+    const url = makeUrl(CONFIG.PATHS.VEGU_INST_SEARCH, `?q=${encodeURIComponent(q)}`);
+    const { res, json } = await debugFetch("vegu-institutions-search", url);
+
+      if (res.ok && json.success === true) list = json.items || [];
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  if (list && list.length > 0) {
+    await lookupById(list[0].vg_id || list[0].id);
   } else {
     setError("No matches. Try different keywords or a full VG ID.");
   }
-}
-  };
+};
 
   const pickResult = async (r) => {
     const id = r.vg_id || r.id;
@@ -243,7 +312,7 @@ export default function MinCVEGUInstitutionUpdate() {
                   Searching…
                 </div>
               )}
-              
+
               {results.map((r, idx) => (
   <button
     key={r.id || r.vg_id}
@@ -319,19 +388,25 @@ export default function MinCVEGUInstitutionUpdate() {
               }}
             >
               <Field label="Name" value={inst.name} />
-              <Field label="VG ID" value={inst.vg_id} />
-              <Field label="Status" value={inst.status} />
-              <Field label="Type" value={inst.institution_type} />
-              <Field label="Category" value={inst.institution_category} />
-              <Field label="Country" value={inst.country} />
-              <Field label="City" value={inst.city} />
-              <Field label="State" value={inst.state} />
-              <Field label="Complaint Email" value={inst.complaint_email} />
-              <Field label="Complaint Phone" value={inst.complaint_phone} />
-              <Field label="Primary Contact" value={inst.primary_contact_name} />
-              <Field label="Website" value={inst.website_url} />
-              <Field label="Updated At" value={inst.updated_at || inst._ts} />
-              <Field label="ETag" value={etag} />
+<Field label="VG ID" value={inst.vg_id} />
+<Field label="Status" value={inst.status} />
+<Field label="Plan" value={inst.plan_type} />
+<Field label="Institution Type" value={inst.institution_type} />
+<Field label="Institution Category" value={inst.institution_category} />
+<Field label="Address1" value={inst.address1} />
+<Field label="Address2" value={inst.address2} />
+<Field label="Comment" value={inst.comment} />
+<Field label="Admin Notes" value={inst.admin_notes} />
+<Field label="Country" value={inst.country} />
+<Field label="Complaint Phone" value={inst.complaint_phone} />
+<Field label="City" value={inst.city} />
+<Field label="State" value={inst.state} />
+<Field label="Complaint Email" value={inst.complaint_email} />
+<Field label="Primary Contact Name" value={inst.primary_contact_name} />
+<Field label="Primary Contact Phone" value={inst.primary_contact_phone} />
+<Field label="Primary Contact Email" value={inst.primary_contact_Email} />
+<Field label="Website" value={inst.website_url} />
+<Field label="Updated At" value={formatLocalTs(inst.updated_at ?? inst._ts)} />
             </div>
 
             <div style={{ textAlign: "right", marginTop: 12 }}>
@@ -375,4 +450,5 @@ function Field({ label, value }) {
       </div>
     </div>
   );
+
 }

--- a/minc-vegu-frontend/src/pages/MinCVEGUInstitutionUpdate.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUInstitutionUpdate.jsx
@@ -1,0 +1,378 @@
+// src/pages/MinCVEGUInstitutionUpdate.jsx  v1.3
+// - No Logout on this screen
+// - Keyword search by name or VG ID (typeahead) + direct ID lookup
+// - Uses MinC backend endpoints (to be added next):
+//     GET  /api/vegu-institutions/{id}
+//     GET  /api/vegu-institutions/search?q=<text>
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "../styles/MinCVeguDashboard.css";
+import "../styles/MinCDashboard.css";
+import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
+import { FaArrowLeft, FaSearch } from "react-icons/fa";
+
+// Adjust to your config setup
+const BASE_URL = import.meta.env.VITE_MINC_API_BASE || "";
+const REACT_FUNCTION_KEY = window.mincFunctionKey || "";
+
+export default function MinCVEGUInstitutionUpdate() {
+  const nav = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [selectedIdx, setSelectedIdx] = useState(-1);
+
+  const [instId, setInstId] = useState(""); // text in the input (can be ID or keyword)
+  const [etag, setEtag] = useState("");
+  const [inst, setInst] = useState(null);
+  const [error, setError] = useState("");
+
+  // search state
+  const [results, setResults] = useState([]);
+  const [searching, setSearching] = useState(false);
+  const searchAbortRef = useRef(null);
+
+  // session guard
+  useEffect(() => {
+    const u = sessionStorage.getItem("mincUser");
+    if (!u) nav("/login", { replace: true });
+  }, [nav]);
+
+  const isLikelyId = useMemo(() => /^VG\d{5,}$/.test(instId.trim()), [instId]);
+
+  // --- search as you type (keywords or partial ID) ---
+  useEffect(() => {
+    const q = instId.trim();
+    setResults([]);
+
+    // only search when not a clear full-id and query has some length
+    if (!q || isLikelyId) return;
+
+    // debounce 250ms
+    const t = setTimeout(async () => {
+      try {
+        if (searchAbortRef.current) searchAbortRef.current.abort();
+        const ctrl = new AbortController();
+        searchAbortRef.current = ctrl;
+
+        setSearching(true);
+        const url =
+          `${BASE_URL}/api/vegu-institutions/search?q=` +
+          encodeURIComponent(q) +
+          (REACT_FUNCTION_KEY ? `&code=${REACT_FUNCTION_KEY}` : "");
+        const res = await fetch(url, { method: "GET", signal: ctrl.signal });
+        const text = await res.text();
+        let json;
+        try { json = JSON.parse(text); } catch { throw new Error(`Non-JSON response (${res.status}): ${text}`); }
+
+        if (!res.ok || json.ok === false) {
+          setResults([]);
+          return;
+        }
+        // Expect: { ok: true, items: [ { id, vg_id, name, status, country, _etag? } ] }
+        setResults(Array.isArray(json.items) ? json.items.slice(0, 10) : []);
+      } catch (e) {
+        if (e.name !== "AbortError") console.error(e);
+      } finally {
+        setSearching(false);
+      }
+    }, 250);
+    return () => clearTimeout(t);
+  }, [instId, isLikelyId, BASE_URL]);
+
+  const lookupById = async (id) => {
+    setError("");
+    setInst(null);
+    setEtag("");
+    setLoading(true);
+    try {
+      const url =
+        `${BASE_URL}/api/vegu-institutions/` +
+        encodeURIComponent(id) +
+        (REACT_FUNCTION_KEY ? `?code=${REACT_FUNCTION_KEY}` : "");
+      const res = await fetch(url, { method: "GET" });
+      const text = await res.text();
+      let json;
+      try { json = JSON.parse(text); } catch { throw new Error(`Non-JSON response (${res.status}): ${text}`); }
+
+      if (!res.ok || json.ok === false) {
+        setError(json.error || `Lookup failed (${res.status})`);
+        return;
+      }
+
+      setInst(json.institution || null);
+      setEtag(json.etag || "");
+    } catch (err) {
+      console.error(err);
+      setError(err.message || "Network error during lookup.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e?.preventDefault?.();
+    const q = instId.trim();
+    if (!q) { setError("Please enter an Institution ID or keywords."); return; }
+    if (isLikelyId) {
+      await lookupById(q);
+    } else if (results.length === 1) {
+      await lookupById(results[0].vg_id || results[0].id);
+    } else {
+  if (results.length > 0) {
+    await lookupById(results[0].vg_id || results[0].id);
+  } else {
+    setError("No matches. Try different keywords or a full VG ID.");
+  }
+}
+  };
+
+  const pickResult = async (r) => {
+    const id = r.vg_id || r.id;
+    setInstId(id);
+    await lookupById(id);
+    setResults([]);
+  };
+
+  return (
+    <div className="vegu-page">
+      <MinCSpinnerOverlay open={loading} />
+
+      <div className="vegu-card">
+        {/* Back only (no Logout on this screen) */}
+        <div
+          className="minc-back-container"
+          role="button"
+          tabIndex={0}
+          onClick={() => nav("/vegu/institutions")}
+          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && nav("/vegu/institutions")}
+          aria-label="Back to Institutions Dashboard"
+        >
+          <FaArrowLeft className="minc-back-icon" />
+          <div className="minc-back-label">Back</div>
+        </div>
+
+        <h1 className="vegu-title">Update Institution</h1>
+
+        {/* Lookup/Search */}
+        <form
+          onSubmit={handleSubmit}
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr auto",
+            gap: 10,
+            maxWidth: 720,
+            margin: "12px auto 6px",
+            position: "relative",
+          }}
+        >
+
+          <input
+  type="text"
+  value={instId}
+  onChange={(e) => {
+    setInstId(e.target.value);
+    setSelectedIdx(-1); // reset selection on text change
+  }}
+  onKeyDown={(e) => {
+    if (isLikelyId || results.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIdx((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      if (selectedIdx >= 0) {
+        e.preventDefault();
+        pickResult(results[selectedIdx]);
+      }
+    }
+  }}
+  placeholder="Enter Institution ID (e.g., VG25001055) or keywords…"
+  aria-label="Institution ID or search keywords"
+  autoFocus
+  style={{
+    padding: "12px 14px",
+    borderRadius: 12,
+    border: "2px solid #9aa5b1",
+    fontFamily: "'Exo 2', sans-serif",
+    fontSize: "1rem",
+  }}
+/>
+
+          <button
+            type="submit"
+            className="btn"
+            style={{
+              padding: "12px 18px",
+              borderRadius: 12,
+              border: "2px solid #F1663D",
+              background: "#F5EE1F",
+              color: "#1B5228",
+              fontWeight: 800,
+              display: "grid",
+              gridAutoFlow: "column",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <FaSearch /> {isLikelyId ? "Lookup" : "Search"}
+          </button>
+
+          {/* Typeahead dropdown */}
+          {!isLikelyId && (results.length > 0 || searching) && (
+            <div
+              role="listbox"
+              style={{
+                position: "absolute",
+                top: "100%",
+                left: 0,
+                right: 0,
+                zIndex: 20,
+                background: "white",
+                border: "2px solid #cbd5e1",
+                borderRadius: 12,
+                marginTop: 6,
+                boxShadow: "0 10px 28px rgba(0,0,0,.12)",
+                maxHeight: 320,
+                overflowY: "auto",
+              }}
+            >
+              {searching && (
+                <div style={{ padding: "10px 12px", color: "#64748b", fontFamily: "'Exo 2', sans-serif" }}>
+                  Searching…
+                </div>
+              )}
+              
+              {results.map((r, idx) => (
+  <button
+    key={r.id || r.vg_id}
+    type="button"
+    onClick={() => pickResult(r)}
+    aria-selected={idx === selectedIdx}
+    style={{
+      display: "grid",
+      gridTemplateColumns: "auto 1fr auto",
+      gap: 10,
+      width: "100%",
+      textAlign: "left",
+      padding: "10px 12px",
+      border: 0,
+      cursor: "pointer",
+      background: idx === selectedIdx ? "#fffef2" : "transparent"
+    }}
+  >
+    <span style={{ opacity: 0.85 }}>🏢</span>
+    <span style={{ color: "#1B5228", fontWeight: 700 }}>
+      {r.name || "—"}
+      <span style={{ color: "#64748b", fontWeight: 500 }}>
+        {" "}— {r.city || "—"}, {r.country || "—"}
+      </span>
+    </span>
+    <span style={{ fontFamily: "Orbitron, sans-serif", color: "#234a39" }}>
+      {r.vg_id || r.id}
+    </span>
+  </button>
+))}
+
+            </div>
+          )}
+        </form>
+
+        {/* Error */}
+        {error && (
+          <div
+            role="alert"
+            style={{
+              maxWidth: 720,
+              margin: "0 auto 12px",
+              background: "#fff6f6",
+              border: "2px solid #f3b8b8",
+              color: "#7a1d1d",
+              borderRadius: 12,
+              padding: "10px 12px",
+              fontFamily: "'Exo 2', sans-serif",
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Result (read-only preview for now) */}
+        {inst && (
+          <div
+            style={{
+              maxWidth: 980,
+              margin: "12px auto 0",
+              background: "#E8F4F9",
+              border: "2px solid #ffb300",
+              borderRadius: 16,
+              padding: 16,
+              boxShadow: "0 6px 20px rgba(0,0,0,.08)",
+            }}
+          >
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(240px,1fr))",
+                gap: 12,
+              }}
+            >
+              <Field label="Name" value={inst.name} />
+              <Field label="VG ID" value={inst.vg_id} />
+              <Field label="Status" value={inst.status} />
+              <Field label="Type" value={inst.institution_type} />
+              <Field label="Category" value={inst.institution_category} />
+              <Field label="Country" value={inst.country} />
+              <Field label="City" value={inst.city} />
+              <Field label="State" value={inst.state} />
+              <Field label="Complaint Email" value={inst.complaint_email} />
+              <Field label="Complaint Phone" value={inst.complaint_phone} />
+              <Field label="Primary Contact" value={inst.primary_contact_name} />
+              <Field label="Website" value={inst.website_url} />
+              <Field label="Updated At" value={inst.updated_at || inst._ts} />
+              <Field label="ETag" value={etag} />
+            </div>
+
+            <div style={{ textAlign: "right", marginTop: 12 }}>
+              <button
+                type="button"
+                className="btn"
+                onClick={() => alert("Edit form will be added next.")}
+                style={{
+                  padding: "10px 16px",
+                  borderRadius: 10,
+                  border: "2px solid #F1663D",
+                  background: "#F5EE1F",
+                  color: "#1B5228",
+                  fontWeight: 800,
+                }}
+              >
+                Edit…
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value }) {
+  return (
+    <div
+      style={{
+        background: "white",
+        border: "1px solid #cbd5e1",
+        borderRadius: 10,
+        padding: "10px 12px",
+        minHeight: 52,
+      }}
+    >
+      <div style={{ fontSize: 12, color: "#475569", marginBottom: 4 }}>{label}</div>
+      <div style={{ color: "#1B5228", fontWeight: 700, wordBreak: "break-word" }}>
+        {value ?? "—"}
+      </div>
+    </div>
+  );
+}

--- a/minc-vegu-frontend/src/pages/MinCVEGUInstitutionsDashboard.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUInstitutionsDashboard.jsx
@@ -1,0 +1,110 @@
+// src/pages/MinCVEGUInstitutionsDashboard.jsx  v1.3 (slim actions)
+
+// MinC → VEGU → Institutions (landing page with slim action cards)
+// Routes:
+//   • /vegu/institutions              (this page)
+//   • /vegu/institutions/update       (next step page — to be implemented)
+
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "../styles/MinCVeguDashboard.css";  // grid + slim actions + back/logout
+import "../styles/MinCDashboard.css";      // modal styles
+import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
+import { FaArrowLeft, FaSignOutAlt } from "react-icons/fa";
+import instLogo from "../assets/minc-workplaces.png";
+
+export default function MinCVeguInstitutionsDashboard() {
+  const nav = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
+
+  // session guard
+  useEffect(() => {
+    const u = sessionStorage.getItem("mincUser");
+    if (!u) nav("/login", { replace: true });
+  }, [nav]);
+
+  const go = (path) => {
+    setLoading(true);
+    setTimeout(() => nav(path), 150);
+  };
+
+  return (
+    <div className="vegu-page">
+      <MinCSpinnerOverlay open={loading} />
+
+      <div className="vegu-card">
+        {/* Back (inside card, top-left) */}
+<div
+  className="minc-back-container"
+  role="button"
+  tabIndex={0}
+  onClick={() => nav("/minc-vegu-dashboard")}
+  onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && nav("/minc-vegu-dashboard")}
+  aria-label="Back to MinC VEGU Main Dashboard"
+>
+  <FaArrowLeft className="minc-back-icon" />
+  <div className="minc-back-label">Back</div>
+</div>
+
+        {/* Logout (inside card, top-right) */}
+        <div
+          className="minc-logout-container"
+          role="button"
+          tabIndex={0}
+          onClick={() => setShowLogoutModal(true)}
+          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && setShowLogoutModal(true)}
+          aria-label="Logout"
+        >
+          <FaSignOutAlt className="minc-logout-icon" />
+          <div className="minc-logout-label">Logout</div>
+        </div>
+
+        <h1 className="vegu-title">Institutions Actions</h1>
+
+        {/* Slim action cards */}
+<div className="minc-menu-list">
+  <button
+    className="minc-menu-item"
+    onClick={() => go("/vegu/institutions/update")}
+    aria-label="Update Institution"
+  >
+    <span className="minc-menu-icon">🏢</span>
+    <span className="minc-menu-label">Update Institution</span>
+  </button>
+</div>
+      </div>
+
+      {/* Confirm Logout modal */}
+      {showLogoutModal && (
+        <div className="minc-modal-backdrop" onClick={() => setShowLogoutModal(false)}>
+          <div
+            className="minc-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="logout-modal-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="logout-modal-title" className="minc-modal-title">Confirm Logout</h3>
+            <p className="minc-modal-text">Are you sure you want to logout?</p>
+            <div className="minc-modal-actions">
+              <button
+                className="btn btn-danger"
+                onClick={() => {
+                  sessionStorage.clear();
+                  setLoading(true);
+                  nav("/login", { replace: true });
+                }}
+              >
+                Yes, Logout
+              </button>
+              <button className="btn btn-secondary" onClick={() => setShowLogoutModal(false)}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/minc-vegu-frontend/src/styles/MinCVeguDashboard.css
+++ b/minc-vegu-frontend/src/styles/MinCVeguDashboard.css
@@ -103,3 +103,42 @@
   margin: 0 auto;          /* centers inside the yellow badge */
 }
 
+/* --- Back & Logout inside the vegu-card --- */
+
+.minc-back-container,
+.minc-logout-container {
+  position: absolute;
+  top: 10px;
+  display: grid;
+  justify-items: center;
+  gap: 2px;
+  user-select: none;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 10px;
+}
+
+.minc-back-container { left: 12px; }
+.minc-logout-container { right: 12px; }
+
+.minc-back-icon,
+.minc-logout-icon {
+  font-size: 22px;
+  color: #F1663D; /* MinC Orange */
+}
+
+.minc-back-label,
+.minc-logout-label {
+  font-size: 12px;
+  color: #6b7280; /* neutral gray */
+}
+
+.minc-back-container:focus,
+.minc-logout-container:focus {
+  outline: 2px solid rgba(241,102,61,0.45);
+  outline-offset: 2px;
+}
+
+/* keep a little top space for the title so it doesn't collide with the icons */
+.vegu-title { margin-top: 22px; }
+

--- a/minc-vegu-frontend/src/styles/MinCVeguDashboard.css
+++ b/minc-vegu-frontend/src/styles/MinCVeguDashboard.css
@@ -142,3 +142,99 @@
 /* keep a little top space for the title so it doesn't collide with the icons */
 .vegu-title { margin-top: 22px; }
 
+/* ===== Slim Action Cards (Option A) ===== */
+
+.vegu-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0,0,0,.10);
+  background: #fffef2;
+  border-color: #6d7a86;               /* hover ring */
+}
+
+.vegu-action:focus-visible {
+  outline: 3px solid rgba(73, 110, 249, .6); /* focus ring */
+  outline-offset: 2px;
+}
+
+/* Icon badge */
+.vegu-action-icon {
+  width: 64px;
+  height: 64px;
+  display: grid;
+  place-items: center;
+  background: #F5EE1F;                 /* yellow badge */
+  border: 2px solid #F1663D;           /* orange ring */
+  border-radius: 14px;
+}
+
+.vegu-action-icon img {
+  display: block;
+  width: 42px;
+  height: 42px;
+  object-fit: contain;
+}
+
+/* Text stack */
+
+.vegu-action-title {
+  font-weight: 800;
+  color: #1B5228;                      /* brand dark green */
+  letter-spacing: .2px;
+}
+
+.vegu-action-desc {
+  font-size: .98rem;
+  line-height: 1.25;
+  color: #214236;
+  opacity: .9;
+  font-family: "Exo 2", sans-serif;
+}
+
+/* Optional “slim selected” halo (for future multi-item state) */
+.vegu-action.selected {
+  border-color: #6b7cff;
+  box-shadow: 0 0 0 3px rgba(107, 124, 255, .18);
+}
+
+/* Keep responsive friendly spacing */
+@media (min-width: 920px) {
+  .vegu-actions { gap: 16px; }
+}
+
+/* Slim menu list for Institutions */
+.minc-menu-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.minc-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #E8F4F9;
+  border: 2px solid #F1663D;
+  border-radius: 12px;
+  padding: 14px 18px;
+  font-family: "Exo 2", sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1B5228;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.minc-menu-item:hover {
+  background: #fffef2;
+  box-shadow: 0 4px 12px rgba(0,0,0,.08);
+}
+
+.minc-menu-icon {
+  font-size: 1.25rem; /* emoji/icon size */
+}
+
+.minc-menu-label {
+  flex: 1;
+}


### PR DESCRIPTION
This PR introduces the VEGU Update Institution workflow (F41), including backend and frontend changes to support institution updates.

Backend
	•	Added vegu_institutions_update function
	•	Support for updating:
	•	Primary contact name, phone, email, website
	•	Admin notes with audit log (timestamp + user)
	•	Auto-refresh of updated_at field on save
	•	Enhanced Cosmos client with eTag handling to prevent conflicts

Frontend
	•	New Update Institution page with:
	•	Institution search by ID or partial phrases
	•	Edit mode with discard-changes confirmation dialog
	•	Differentiation between editable and read-only fields (styling update)
	•	Display of full admin notes in reverse chronological order
	•	Improved UX:
	•	Preserves Institution Type/Category when editing
	•	Shows existing admin notes before adding new ones
	•	Updates timestamp after successful save

Other
	•	Config paths extended for update endpoints
	•	Cleanup of redundant UI elements (e.g., duplicate Admin Notes)