### PR TITLE
Feature/201 f42:  Add Responder Update Functionality with Lock Control, Timestamp Fixes, and Navigation Safeguards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ minc-vegu-frontend/.env*
 minc-vegu-frontend/src/utils/config.js
 minc-vegu-backend/local-settings-params.txt
 Summaries/
+minc-vegu-backend/.venv312/

--- a/minc-vegu-backend/function_app.py
+++ b/minc-vegu-backend/function_app.py
@@ -13,3 +13,6 @@ import minc_verify_email_otp    # noqa: F401
 import vegu_institutions_search  # noqa: F401
 import vegu_institutions_get     # noqa: F401
 import vegu_institutions_update  # noqa: F401
+import vegu_responders_search   # noqa: F401
+import vegu_responders_get      # noqa: F401
+import vegu_responders_update   # noqa: F401

--- a/minc-vegu-backend/shared/normalizers.py
+++ b/minc-vegu-backend/shared/normalizers.py
@@ -1,0 +1,31 @@
+# shared/normalizers.py 1.4
+from typing import Any, Dict, Optional
+
+def normalize_responder(doc: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not doc:
+        return {}
+    return {
+        "vg_id":              doc.get("vg_id") or doc.get("id") or "",
+        "id":                 doc.get("id") or doc.get("vg_id") or "",
+        "email":              doc.get("email", ""),
+        "institution_name":   doc.get("institution_name") or doc.get("institutionName") or "",
+        "institution_id":     doc.get("institution_id") or doc.get("institutionId") or "",
+        "first_name":         doc.get("first_name") or doc.get("firstName") or "",
+        "middle_name":        doc.get("middle_name") or doc.get("middleName") or "",
+        "last_name":          doc.get("last_name") or doc.get("lastName") or "",
+        "phone":              doc.get("phone", ""),
+        "country":            doc.get("country", ""),
+        "department":         doc.get("department", ""),
+        "status":             doc.get("status", ""),
+        "timezone":           doc.get("timezone", ""),
+        # timestamps (strings or None)
+        "local_created_at":   doc.get("local_created_at"),
+        "created_at":         doc.get("created_at"),
+        "last_login":         doc.get("last_login"),
+        "reset_locked_until": doc.get("reset_locked_until"),
+        # prefer explicit updated_at; else use _ts
+        "updated_at":         doc.get("updated_at") or doc.get("_ts"),
+        # extras
+        "admin_notes":        doc.get("admin_notes", ""),
+        "_ts":                doc.get("_ts"),
+    }

--- a/minc-vegu-backend/shared/vegu_cosmos_client.py
+++ b/minc-vegu-backend/shared/vegu_cosmos_client.py
@@ -275,7 +275,7 @@ def update_responder_fields(vg_id: str, patch: dict, expected_etag: str | None =
     allowed = {
         "firstName","middleName","lastName",
         "phone","country","department","status",
-        "admin_notes"
+        "admin_notes", "updated_at", "reset_locked_until"
     }
     updated = dict(current)
     for k, v in (patch or {}).items():

--- a/minc-vegu-backend/vegu_responders_get/__init__.py
+++ b/minc-vegu-backend/vegu_responders_get/__init__.py
@@ -6,6 +6,7 @@ import azure.functions as func
 from function_app import app
 from shared.auth import http_auth_level
 from shared.vegu_cosmos_client import get_responder_by_vg_id
+from shared.normalizers import normalize_responder
 
 def _resp(obj, status=200):
     return func.HttpResponse(
@@ -62,7 +63,7 @@ def run(req: func.HttpRequest) -> func.HttpResponse:
             return _resp({"success": False, "error": "Responder not found"}, 404)
 
         etag = doc.get("_etag")
-        responder = _normalize(doc)
+        responder = normalize_responder(doc)
         return _resp({"success": True, "responder": responder, "etag": etag}, 200)
     except Exception as e:
         logging.exception("vegu_responders_get failed")

--- a/minc-vegu-backend/vegu_responders_get/__init__.py
+++ b/minc-vegu-backend/vegu_responders_get/__init__.py
@@ -1,0 +1,37 @@
+# vegu_responders_get/__init__.py  v1.4
+
+import json
+import azure.functions as func
+from function_app import app
+from shared.auth import http_auth_level
+from shared.vegu_cosmos_client import get_responder_by_vg_id
+
+
+def _resp(obj, status=200):
+    return func.HttpResponse(
+        json.dumps(obj),
+        status_code=status,
+        mimetype="application/json"
+    )
+
+
+@app.function_name(name="vegu_responders_get")
+@app.route(route="vegu-responders/{vg_id}", methods=[func.HttpMethod.GET], auth_level=http_auth_level())
+def run(req: func.HttpRequest) -> func.HttpResponse:
+    vg_id = req.route_params.get("vg_id")
+    if not vg_id:
+        return _resp({"success": False, "error": "vg_id is required"}, 400)
+
+    try:
+        doc = get_responder_by_vg_id(vg_id)
+        if not doc:
+            return _resp({"success": False, "error": "Responder not found"}, 404)
+
+        etag = doc.get("_etag")
+        # trim noisy internals before returning (keep _ts for FE timestamp formatting if you want)
+        for f in ("_rid", "_self", "_attachments"):
+            doc.pop(f, None)
+
+        return _resp({"success": True, "responder": doc, "etag": etag}, 200)
+    except Exception:
+        return _resp({"success": False, "error": "server_error"}, 500)

--- a/minc-vegu-backend/vegu_responders_search/__init__.py
+++ b/minc-vegu-backend/vegu_responders_search/__init__.py
@@ -1,0 +1,73 @@
+# vegu_responders_search/__init__.py V1.4
+
+import os
+import json
+import azure.functions as func
+from function_app import app  # ← use the single global app
+from azure.cosmos import PartitionKey
+from shared.vegu_cosmos_client import get_vegu_db  # we already use this elsewhere
+
+RESPONDERS_CONTAINER = os.getenv("VEGU_CONTAINER_RESPONDERS", "responders")
+
+@app.route(route="vegu-responders-search", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+def vegu_responders_search(req: func.HttpRequest) -> func.HttpResponse:
+    try:
+        q = (req.params.get("q") or "").strip()
+        if not q:
+            return func.HttpResponse(
+                json.dumps({"success": True, "items": []}),
+                mimetype="application/json"
+            )
+
+        db = get_vegu_db()
+        container = db.get_container_client(RESPONDERS_CONTAINER)
+
+        # Case-insensitive substring matching on multiple fields
+        sql = """
+        SELECT TOP 20
+            c.id, c.vg_id, c.email,
+            c.firstName, c.middleName, c.lastName,
+            c.institution_name, c.institution_id
+        FROM c
+        WHERE
+            CONTAINS(c.vg_id, @q, true)
+            OR CONTAINS(c.email, @q, true)
+            OR CONTAINS(c.firstName, @q, true)
+            OR CONTAINS(c.middleName, @q, true)
+            OR CONTAINS(c.lastName, @q, true)
+            OR CONTAINS(c.institution_name, @q, true)
+        """
+        params = [{"name": "@q", "value": q}]
+        items_iter = container.query_items(
+            query=sql,
+            parameters=params,
+            enable_cross_partition_query=True
+        )
+        items = list(items_iter)
+
+        # Normalize a tiny shape for FE list
+        out = []
+        for it in items:
+            out.append({
+                "id": it.get("id"),
+                "vg_id": it.get("vg_id") or it.get("id"),
+                "email": it.get("email"),
+                "firstName": it.get("firstName"),
+                "middleName": it.get("middleName"),
+                "lastName": it.get("lastName"),
+                "institution_name": it.get("institution_name"),
+                "institution_id": it.get("institution_id"),
+            })
+
+        return func.HttpResponse(
+            json.dumps({"success": True, "items": out}),
+            mimetype="application/json"
+        )
+    except Exception as e:
+        # Keep the message generic for FE, but print detail to logs
+        print("vegu_responders_search error:", repr(e))
+        return func.HttpResponse(
+            json.dumps({"success": False, "error": "server_error"}),
+            mimetype="application/json",
+            status_code=500
+        )

--- a/minc-vegu-backend/vegu_responders_update/__init__.py
+++ b/minc-vegu-backend/vegu_responders_update/__init__.py
@@ -1,0 +1,96 @@
+# vegu_responders_update/__init__.py  v1.4
+
+import json
+import logging
+from datetime import datetime, timezone
+
+import azure.functions as func
+from function_app import app
+from shared.auth import http_auth_level
+from shared.vegu_cosmos_client import (
+    get_responder_by_vg_id,
+    update_responder_fields,
+)
+
+def _resp(obj, status=200):
+    return func.HttpResponse(
+        json.dumps(obj),
+        status_code=status,
+        mimetype="application/json"
+    )
+
+# Fields we allow FE to modify for Responders (others are system-controlled or sensitive)
+ALLOWED_FIELDS = {
+    "firstName", "middleName", "lastName",
+    "phone", "country", "department",
+    "status",
+    "admin_notes",          # append-only policy is enforced in FE; BE allows string set
+    # timestamps:
+    "updated_at",           # BE will set/override this
+    # explicit non-editable here: id, vg_id, email, timezone, local_created_at, created_at,
+    # last_login, institution_name, institution_id, password, role, reset_* counters, etc.
+}
+
+@app.function_name(name="vegu_responders_update")
+@app.route(route="vegu-responders-update", methods=[func.HttpMethod.POST, func.HttpMethod.PATCH], auth_level=http_auth_level())
+def run(req: func.HttpRequest) -> func.HttpResponse:
+    try:
+        body = req.get_json()
+    except ValueError:
+        return _resp({"success": False, "error": "Invalid JSON."}, 400)
+
+    vg_id = (body or {}).get("vg_id") or (body or {}).get("id")
+    if not vg_id:
+        return _resp({"success": False, "error": "vg_id is required"}, 400)
+
+    patch_in = (body or {}).get("patch") or {}
+    if not isinstance(patch_in, dict) or not patch_in:
+        return _resp({"success": False, "error": "patch object is required"}, 400)
+
+    client_etag = (body or {}).get("etag")
+
+    # Load current
+    current = get_responder_by_vg_id(vg_id)
+    if not current:
+        return _resp({"success": False, "error": "Responder not found"}, 404)
+
+    # Optimistic concurrency (light check before conditional replace)
+    server_etag = current.get("_etag")
+    if client_etag and server_etag and client_etag != server_etag:
+        return _resp({
+            "success": False,
+            "error": "etag_mismatch",
+            "message": "The record was modified by someone else. Refresh and retry.",
+            "etag": server_etag
+        }, 409)
+
+    # Sanitize patch keys
+    patch = {k: v for k, v in patch_in.items() if k in ALLOWED_FIELDS}
+
+    if not patch:
+        return _resp({"success": False, "error": "No allowed fields in patch."}, 400)
+
+    # BE owns updated_at (UTC)
+    patch["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    try:
+        updated = update_responder_fields(vg_id=vg_id, patch=patch, expected_etag=server_etag)
+    except ValueError as ve:
+        return _resp({"success": False, "error": str(ve)}, 404)
+    except PermissionError:
+        # ETag mismatch during conditional replace
+        return _resp({
+            "success": False,
+            "error": "etag_mismatch",
+            "message": "The record was modified by someone else. Refresh and retry.",
+            "etag": get_responder_by_vg_id(vg_id).get("_etag")  # best-effort fresh etag
+        }, 409)
+    except Exception:
+        logging.exception("vegu_responders_update failed")
+        return _resp({"success": False, "error": "server_error"}, 500)
+
+    etag = updated.get("_etag")
+    for f in ("_rid", "_self", "_attachments"):
+        updated.pop(f, None)
+
+    return _resp({"success": True, "responder": updated, "etag": etag}, 200)

--- a/minc-vegu-backend/vegu_responders_update/__init__.py
+++ b/minc-vegu-backend/vegu_responders_update/__init__.py
@@ -1,8 +1,10 @@
 # vegu_responders_update/__init__.py  v1.4
 
 import json
+import re
 import logging
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 import azure.functions as func
 from function_app import app
@@ -12,6 +14,7 @@ from shared.vegu_cosmos_client import (
     get_responder_by_vg_id,
     update_responder_fields,
 )
+_DT_PAT = re.compile(r"^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2}))?)?$")
 
 def _resp(obj, status=200):
     return func.HttpResponse(
@@ -25,6 +28,7 @@ KEY_SYNONYMS = {
     "first_name": "firstName",
     "middle_name": "middleName",
     "last_name": "lastName",
+    "resetLockedUntil": "reset_locked_until",
 }
 
 # Only these fields are editable by FE (BE will also set updated_at itself)
@@ -32,7 +36,8 @@ ALLOWED_FIELDS = {
     "firstName", "middleName", "lastName",
     "phone", "country", "department",
     "status",
-    "admin_notes",  # FE appends; BE just stores the provided string
+    "admin_notes",
+    "reset_locked_until",
 }
 
 @app.function_name(name="vegu_responders_update")
@@ -82,6 +87,16 @@ def run(req: func.HttpRequest) -> func.HttpResponse:
     current = get_responder_by_vg_id(vg_id)
     if not current:
         return _resp({"success": False, "error": "Responder not found"}, 404)
+
+    # Normalize reset_locked_until input (string) to ISO Z using responder's TZ
+    if "reset_locked_until" in patch:
+        val = patch["reset_locked_until"]
+        if isinstance(val, str) and val.strip():
+            tz = current.get("timezone") or current.get("time_zone") or "UTC"
+            patch["reset_locked_until"] = _to_iso_from_local(val, tz)
+        elif val in ("", None):
+             # allow clearing the lock
+            patch["reset_locked_until"] = None
 
     server_etag = current.get("_etag")
     if client_etag and server_etag and client_etag != server_etag:
@@ -133,3 +148,40 @@ def run(req: func.HttpRequest) -> func.HttpResponse:
     },
     200
 )
+
+def _expand_date_to_eod_iso(date_str: str, responder_tz: str) -> str:
+    """
+    Convert 'YYYY-MM-DD' + 23:59:59 in responder_tz to ISO8601 Z.
+    """
+    try:
+        y, m, d = map(int, date_str.split("-"))
+        tz = ZoneInfo(responder_tz) if responder_tz else timezone.utc
+        dt_local = datetime(y, m, d, 23, 59, 59, tzinfo=tz)
+        return dt_local.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except Exception:
+        # If parsing fails, just return the original string; validation below can reject it.
+        return date_str
+
+def _to_iso_from_local(local_str: str, responder_tz: str) -> str:
+    """
+    Accepts:
+      - YYYY-MM-DD
+      - YYYY-MM-DDTHH:MM
+      - YYYY-MM-DDTHH:MM:SS
+      - same with space instead of 'T'
+    Interprets as local time in responder_tz, converts to ISO8601 Z.
+    Date-only is treated as 23:59:59.
+    """
+    m = _DT_PAT.match(local_str.strip())
+    if not m:
+      # leave as-is; validation will fail at write if it's nonsense
+      return local_str
+
+    y, mm, dd = map(int, m.group(1,2,3))
+    hh = int(m.group(4) or 23)
+    mi = int(m.group(5) or 59)
+    ss = int(m.group(6) or 59)
+
+    tz = ZoneInfo(responder_tz) if responder_tz else timezone.utc
+    dt_local = datetime(y, mm, dd, hh, mi, ss, tzinfo=tz)
+    return dt_local.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/minc-vegu-backend/vegu_responders_update/__init__.py
+++ b/minc-vegu-backend/vegu_responders_update/__init__.py
@@ -1,4 +1,4 @@
-# vegu_responders_update/__init__.py  v1.5
+# vegu_responders_update/__init__.py  v1.4
 
 import json
 import logging
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import azure.functions as func
 from function_app import app
 from shared.auth import http_auth_level
+from shared.normalizers import normalize_responder
 from shared.vegu_cosmos_client import (
     get_responder_by_vg_id,
     update_responder_fields,
@@ -124,4 +125,11 @@ def run(req: func.HttpRequest) -> func.HttpResponse:
     for f in ("_rid", "_self", "_attachments"):
         updated.pop(f, None)
 
-    return _resp({"success": True, "responder": updated, "etag": etag}, 200)
+    return _resp(
+    {
+        "success": True,
+        "responder": normalize_responder(updated),
+        "etag": updated.get("_etag")
+    },
+    200
+)

--- a/minc-vegu-backend/vegu_responders_update/__init__.py
+++ b/minc-vegu-backend/vegu_responders_update/__init__.py
@@ -1,4 +1,4 @@
-# vegu_responders_update/__init__.py  v1.4
+# vegu_responders_update/__init__.py  v1.5
 
 import json
 import logging
@@ -19,20 +19,27 @@ def _resp(obj, status=200):
         mimetype="application/json"
     )
 
-# Fields we allow FE to modify for Responders (others are system-controlled or sensitive)
+# map any snake_case to the camelCase we actually store
+KEY_SYNONYMS = {
+    "first_name": "firstName",
+    "middle_name": "middleName",
+    "last_name": "lastName",
+}
+
+# Only these fields are editable by FE (BE will also set updated_at itself)
 ALLOWED_FIELDS = {
     "firstName", "middleName", "lastName",
     "phone", "country", "department",
     "status",
-    "admin_notes",          # append-only policy is enforced in FE; BE allows string set
-    # timestamps:
-    "updated_at",           # BE will set/override this
-    # explicit non-editable here: id, vg_id, email, timezone, local_created_at, created_at,
-    # last_login, institution_name, institution_id, password, role, reset_* counters, etc.
+    "admin_notes",  # FE appends; BE just stores the provided string
 }
 
 @app.function_name(name="vegu_responders_update")
-@app.route(route="vegu-responders-update", methods=[func.HttpMethod.POST, func.HttpMethod.PATCH], auth_level=http_auth_level())
+@app.route(
+    route="vegu-responders-update",
+    methods=[func.HttpMethod.POST, func.HttpMethod.PATCH],
+    auth_level=http_auth_level()
+)
 def run(req: func.HttpRequest) -> func.HttpResponse:
     try:
         body = req.get_json()
@@ -43,18 +50,38 @@ def run(req: func.HttpRequest) -> func.HttpResponse:
     if not vg_id:
         return _resp({"success": False, "error": "vg_id is required"}, 400)
 
+    client_etag = (body or {}).get("etag")
     patch_in = (body or {}).get("patch") or {}
     if not isinstance(patch_in, dict) or not patch_in:
         return _resp({"success": False, "error": "patch object is required"}, 400)
 
-    client_etag = (body or {}).get("etag")
+    # Normalize keys first (snake_case -> camelCase), then filter
+    normalized = {}
+    for k, v in patch_in.items():
+        k2 = KEY_SYNONYMS.get(k, k)
+        normalized[k2] = v
 
-    # Load current
+    # Now enforce allowed list
+    patch = {k: v for k, v in normalized.items() if k in ALLOWED_FIELDS}
+
+    if not patch:
+        return _resp({"success": False, "error": "No allowed fields in patch."}, 400)
+
+    # Cheap sanitation
+    if "status" in patch and isinstance(patch["status"], str):
+        patch["status"] = patch["status"].strip().lower()
+        if patch["status"] not in {"active", "pending", "suspended", "locked", "expired"}:
+            return _resp({"success": False, "error": "Invalid status value."}, 400)
+
+    if "admin_notes" in patch and patch["admin_notes"] is None:
+        # prevent nulling notes accidentally
+        patch.pop("admin_notes")
+
+    # Load current (for ETag + existence)
     current = get_responder_by_vg_id(vg_id)
     if not current:
         return _resp({"success": False, "error": "Responder not found"}, 404)
 
-    # Optimistic concurrency (light check before conditional replace)
     server_etag = current.get("_etag")
     if client_etag and server_etag and client_etag != server_etag:
         return _resp({
@@ -64,26 +91,30 @@ def run(req: func.HttpRequest) -> func.HttpResponse:
             "etag": server_etag
         }, 409)
 
-    # Sanitize patch keys
-    patch = {k: v for k, v in patch_in.items() if k in ALLOWED_FIELDS}
-
-    if not patch:
-        return _resp({"success": False, "error": "No allowed fields in patch."}, 400)
-
-    # BE owns updated_at (UTC)
+    # BE owns updated_at (UTC, ISO8601 Z)
     patch["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     try:
-        updated = update_responder_fields(vg_id=vg_id, patch=patch, expected_etag=server_etag)
+        updated = update_responder_fields(
+            vg_id=vg_id,
+            patch=patch,
+            expected_etag=server_etag  # helper should do conditional replace if provided
+        )
     except ValueError as ve:
+        # e.g., responder not found in helper
         return _resp({"success": False, "error": str(ve)}, 404)
     except PermissionError:
-        # ETag mismatch during conditional replace
+        # ETag mismatch at write time
+        try:
+            fresh = get_responder_by_vg_id(vg_id) or {}
+            fresh_etag = fresh.get("_etag")
+        except Exception:
+            fresh_etag = None
         return _resp({
             "success": False,
             "error": "etag_mismatch",
             "message": "The record was modified by someone else. Refresh and retry.",
-            "etag": get_responder_by_vg_id(vg_id).get("_etag")  # best-effort fresh etag
+            "etag": fresh_etag
         }, 409)
     except Exception:
         logging.exception("vegu_responders_update failed")

--- a/minc-vegu-frontend/src/App.jsx
+++ b/minc-vegu-frontend/src/App.jsx
@@ -7,6 +7,8 @@ import MinCRegisterPage from "./pages/MinCRegisterPage";
 import MinCContactSupportPage from "./pages/MinCContactSupportPage";
 import MinCVeguInstitutionsDashboard from "./pages/MinCVEGUInstitutionsDashboard";
 import MinCVEGUInstitutionUpdate from "./pages/MinCVEGUInstitutionUpdate";
+import MinCVEGURespondersDashboard from "./pages/MinCVEGURespondersDashboard";
+import MinCVEGUResponderUpdate from "./pages/MinCVEGUResponderUpdate";
 
 function getSessionUser() {
   try {
@@ -60,6 +62,8 @@ function App() {
         <Route path="/minc-vegu-dashboard" element={<RequireAuth><MinCVeguDashboard /></RequireAuth>} />
         <Route path="/vegu/institutions" element={<RequireAuth><MinCVeguInstitutionsDashboard /></RequireAuth>} />
         <Route path="/vegu/institutions/update" element={<RequireAuth><MinCVEGUInstitutionUpdate /></RequireAuth>} />
+        <Route path="/vegu/responders" element={<MinCVEGURespondersDashboard />} />
+        <Route path="/vegu/responders/update" element={<MinCVEGUResponderUpdate />} />
       </Routes>
     </Router>
   );

--- a/minc-vegu-frontend/src/pages/MinCLandingPage.jsx
+++ b/minc-vegu-frontend/src/pages/MinCLandingPage.jsx
@@ -1,17 +1,19 @@
+//src/pages/MinCLandingPage.jsx 1.4
+
 import React, { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import "../styles/MinCGlobal.css";
 import "../styles/MinCSpinner.css";
 import mincLogo from '../assets/minc-logo.png';
 import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
+import UsePageTitle from "../utils/UsePageTitle";
+
 
 function MinCLandingPage() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    document.title = "Welcome to MinC Portal";
-  }, []);
+UsePageTitle("Welcome to MinC Portal");
 
   const goLogin = () => {
     setLoading(true);

--- a/minc-vegu-frontend/src/pages/MinCMainDashboard.jsx
+++ b/minc-vegu-frontend/src/pages/MinCMainDashboard.jsx
@@ -1,4 +1,4 @@
-// src/pages/MinCMainDashboard.jsx v1.1
+// src/pages/MinCMainDashboard.jsx v1.4
 
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -6,8 +6,11 @@ import { FaSignOutAlt } from "react-icons/fa";
 import MMSLogo from "../assets/MMS_Logo.png";
 import VEGULogo from "../assets/VEGU_Logo.png";
 import "../styles/MinCDashboard.css";
+import UsePageTitle from "../utils/UsePageTitle";
 
 export default function MinCMainDashboard() {
+  UsePageTitle("MinC Main Dashboard");
+  
   const nav = useNavigate();
   const [showDialog, setShowDialog] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);

--- a/minc-vegu-frontend/src/pages/MinCVEGUDashboard.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUDashboard.jsx
@@ -1,4 +1,4 @@
-// src/pages/MinCVeguDashboard.jsx v1.3
+// src/pages/MinCVeguDashboard.jsx v1.4
 
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -9,8 +9,11 @@ import userLogo from "../assets/minc-users.png";
 import responderLogo from "../assets/minc-responders.png";
 import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
 import { FaArrowLeft, FaSignOutAlt } from "react-icons/fa";
+import UsePageTitle from "../utils/UsePageTitle";
 
 export default function MinCVeguDashboard() {
+  UsePageTitle("MinC VEGU Dashboard");
+
   const nav = useNavigate();
   const [loading, setLoading] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);

--- a/minc-vegu-frontend/src/pages/MinCVEGUInstitutionUpdate.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUInstitutionUpdate.jsx
@@ -1,4 +1,4 @@
-// src/pages/MinCVEGUInstitutionUpdate.jsx  v1.3
+// src/pages/MinCVEGUInstitutionUpdate.jsx  v1.4
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -7,6 +7,7 @@ import "../styles/MinCDashboard.css";
 import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
 import { FaArrowLeft, FaSearch } from "react-icons/fa";
 import { CONFIG } from "../utils/config";
+import UsePageTitle from "../utils/UsePageTitle";
 
 const debugFetch = async (label, url, init = {}) => {
   console.log(`➡️ ${label} REQ`, url, init);
@@ -111,6 +112,8 @@ const makeUrl = (path, qs = "") => {
 };
 
 export default function MinCVEGUInstitutionUpdate() {
+  UsePageTitle("MinC VEGU Institution Update");
+  
   const nav = useNavigate();
   const [loading, setLoading] = useState(false);
   const [selectedIdx, setSelectedIdx] = useState(-1);

--- a/minc-vegu-frontend/src/pages/MinCVEGUInstitutionsDashboard.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUInstitutionsDashboard.jsx
@@ -1,9 +1,4 @@
-// src/pages/MinCVEGUInstitutionsDashboard.jsx  v1.3 (slim actions)
-
-// MinC → VEGU → Institutions (landing page with slim action cards)
-// Routes:
-//   • /vegu/institutions              (this page)
-//   • /vegu/institutions/update       (next step page — to be implemented)
+// src/pages/MinCVEGUInstitutionsDashboard.jsx  v1.4
 
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -12,8 +7,12 @@ import "../styles/MinCDashboard.css";      // modal styles
 import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
 import { FaArrowLeft, FaSignOutAlt } from "react-icons/fa";
 import instLogo from "../assets/minc-workplaces.png";
+import UsePageTitle from "../utils/UsePageTitle";
+
 
 export default function MinCVeguInstitutionsDashboard() {
+  UsePageTitle("MinC VEGU Institution Actions");
+  
   const nav = useNavigate();
   const [loading, setLoading] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);

--- a/minc-vegu-frontend/src/pages/MinCVEGUResponderUpdate.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUResponderUpdate.jsx
@@ -272,8 +272,9 @@ export default function MinCVEGUResponderUpdate() {
         return;
       }
 
-      setResponder(json.responder);
-      seedDraft(json.responder);
+      const r = normalizeResponder(json.responder);
+      setResponder(r);
+      seedDraft(r);
       setEtag(json.etag || "");
       setNewNote("");
       setEditMode(false);
@@ -447,13 +448,34 @@ export default function MinCVEGUResponderUpdate() {
             style={{
               maxWidth: 980,
               margin: "12px auto 0",
-              background: "#E8F4F9",
-              border: "2px solid #ffb300",
+              background: editMode ? "#FFFDF1" : "#E8F4F9",        // warmer bg when editing
+              border: `2px solid ${editMode ? "#f59e0b" : "#ffb300"}`,
               borderRadius: 16,
               padding: 16,
               boxShadow: "0 6px 20px rgba(0,0,0,.08)",
             }}
           >
+
+            {editMode && (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  marginBottom: 10,
+                  background: "#FFF5DD",
+                  border: "1px solid #f59e0b",
+                  color: "#92400e",
+                  padding: "8px 10px",
+                  borderRadius: 10,
+                  fontWeight: 700,
+                }}
+              >
+                <span aria-hidden="true">🔒</span>
+                Editing responder (read-only fields are locked)
+              </div>
+            )}
+
 <div style={{ display:"grid", gridTemplateColumns:"repeat(auto-fit, minmax(240px,1fr))", gap:12 }}>
   {/* identity / read-only */}
   <Field label="VG Responder ID" value={responder.vg_id} readOnly />
@@ -472,11 +494,11 @@ export default function MinCVEGUResponderUpdate() {
   <RWSelect edit={editMode} label="Status"      value={draft?.status     || ""} onChange={(v)=>updateDraft("status", v)} options={STATUS_OPTIONS} />
 
   {/* times (use the camelCase fields produced by normalizeResponder) */}
-  <Field label="Local Created At"   value={formatLocalTs(responder.localCreatedAt, responder.timezone)} />
-  <Field label="Created At (UTC)"   value={formatLocalTs(responder.createdAt, "UTC")} />
-  <Field label="Last Login"         value={formatLocalTs(responder.lastLogin, responder.timezone)} />
+  <Field label="Local Created At"   value={formatLocalTs(responder.localCreatedAt, responder.timezone)} readOnly/>
+  <Field label="Created At (UTC)"   value={formatLocalTs(responder.createdAt, "UTC")} readOnly/>
+  <Field label="Last Login"         value={formatLocalTs(responder.lastLogin, responder.timezone)} readOnly/>
   <Field label="Reset Locked Until" value={formatLocalTs(responder.resetLockedUntil, responder.timezone)} />
-  <Field label="Updated At"         value={formatLocalTs(responder.updatedAt, responder.timezone)} />
+  <Field label="Updated At"         value={formatLocalTs(responder.updatedAt, responder.timezone)} readOnly/>
 </div>
 
             {/* Admin notes */}

--- a/minc-vegu-frontend/src/pages/MinCVEGUResponderUpdate.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUResponderUpdate.jsx
@@ -1,0 +1,396 @@
+// src/pages/MinCVEGUResponderUpdate.jsx  v1.4
+// - No Logout on this screen
+// - Search by Responder VG ID or keywords (name, email, phone)
+// - Uses (to-be-wired) endpoints:
+//     GET  /api/vegu-responders/{id}
+//     GET  /api/vegu-responders-search?q=<text>
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "../styles/MinCVeguDashboard.css";
+import "../styles/MinCDashboard.css";
+import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
+import { FaArrowLeft, FaSearch } from "react-icons/fa";
+import { CONFIG } from "../utils/config";
+
+const debugFetch = async (label, url, init = {}) => {
+  console.log(`➡️ ${label} REQ`, url, init);
+  const res = await fetch(url, init);
+  const text = await res.text();
+  console.log(`⬅️ ${label} RESP ${res.status}`, text);
+  let json; try { json = JSON.parse(text); } catch { json = { parseError: true, text }; }
+  return { res, json };
+};
+
+const makeUrl = (path, qs = "") => {
+  const base = CONFIG.API_BASE || "";
+  const key  = CONFIG.API_KEY;
+  const sep  = qs.includes("?") ? "&" : "?";
+  const withKey = key ? `${qs}${sep}code=${encodeURIComponent(key)}` : qs || "";
+  const url = `${base}${path}${withKey}`;
+  console.debug("[MinC] calling:", url);
+  return url;
+};
+
+// local time → readable
+function formatLocalTs(input) {
+  if (input === null || input === undefined || input === "") return "—";
+  let d;
+  try {
+    if (typeof input === "number") d = new Date(input * 1000);
+    else d = new Date(input);
+    if (Number.isNaN(d.getTime())) return String(input);
+    const parts = new Intl.DateTimeFormat(undefined, {
+      year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", second: "2-digit",
+      hour12: false, timeZoneName: "short",
+    }).formatToParts(d);
+    const get = (t) => parts.find((p) => p.type === t)?.value || "";
+    return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}:${get("second")} ${get("timeZoneName")}`;
+  } catch {
+    return String(input);
+  }
+}
+
+export default function MinCVEGUResponderUpdate() {
+  const nav = useNavigate();
+
+  // session guard
+  useEffect(() => {
+    const u = sessionStorage.getItem("mincUser");
+    if (!u) nav("/login", { replace: true });
+  }, [nav]);
+
+  const [loading, setLoading] = useState(false);
+  const [selectedIdx, setSelectedIdx] = useState(-1);
+
+  const [qText, setQText] = useState("");
+  const [responder, setResponder] = useState(null);
+  const [error, setError] = useState("");
+
+  // typeahead
+  const [results, setResults] = useState([]);
+  const [searching, setSearching] = useState(false);
+  const searchAbortRef = useRef(null);
+
+  const isLikelyId = useMemo(() => /^VG\d{5,}$/.test(qText.trim()), [qText]);
+
+  // --- search as you type for keywords (not for full-id) ---
+  useEffect(() => {
+    const q = qText.trim();
+    setResults([]);
+    if (!q || isLikelyId) return;
+
+    const t = setTimeout(async () => {
+      try {
+        if (searchAbortRef.current) searchAbortRef.current.abort();
+        const ctrl = new AbortController();
+        searchAbortRef.current = ctrl;
+
+        setSearching(true);
+        const url = makeUrl(CONFIG.PATHS.RESP_SEARCH, `?q=${encodeURIComponent(q)}`);
+        const { res, json } = await debugFetch("responders-search(typeahead)", url, { method: "GET", signal: ctrl.signal });
+        if (!res.ok || json.success !== true) { setResults([]); return; }
+        // Expect: { success:true, items:[{ vg_id, first_name, last_name, email, phone, institution_id, institution_name, ... }] }
+        setResults(Array.isArray(json.items) ? json.items.slice(0, 10) : []);
+      } catch (e) {
+        if (e.name !== "AbortError") console.error(e);
+      } finally {
+        setSearching(false);
+      }
+    }, 250);
+
+    return () => clearTimeout(t);
+  }, [qText, isLikelyId]);
+
+  const lookupById = async (id) => {
+    setError("");
+    setResponder(null);
+    setLoading(true);
+    try {
+      const urlGet = makeUrl(`${CONFIG.PATHS.RESP_GET}/${encodeURIComponent(id)}`);
+      let { res, json } = await debugFetch("responders-get", urlGet);
+      if (res.ok && json && json.success && json.responder) {
+        setResponder(json.responder);
+        return;
+      }
+      // fallback: search by q=id and pick first match
+      const urlSearch = makeUrl(CONFIG.PATHS.RESP_SEARCH, `?q=${encodeURIComponent(id)}`);
+      ({ res, json } = await debugFetch("responders-search(fallback)", urlSearch));
+      if (res.ok && json && json.success && Array.isArray(json.items) && json.items.length) {
+        setResponder(json.items[0]);
+        return;
+      }
+      setError((json && json.error) || "Responder not found.");
+    } catch (e) {
+      console.error(e);
+      setError(e.message || "Network error during lookup.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e?.preventDefault?.();
+    setError("");
+    const q = qText.trim();
+    if (!q) { setError("Please enter a Responder ID or keywords."); return; }
+
+    if (isLikelyId) { await lookupById(q); return; }
+
+    // if no live typeahead results, perform a one-shot search
+    let list = results;
+    if (!list || list.length === 0) {
+      try {
+        setSearching(true);
+        const url = makeUrl(CONFIG.PATHS.RESP_SEARCH, `?q=${encodeURIComponent(q)}`);
+        const { res, json } = await debugFetch("responders-search", url);
+        if (res.ok && json.success === true) list = json.items || [];
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setSearching(false);
+      }
+    }
+    if (list && list.length > 0) {
+      await lookupById(list[0].vg_id || list[0].id);
+    } else {
+      setError("No matches. Try different keywords or a full VG ID.");
+    }
+  };
+
+  const pickResult = async (r) => {
+    const id = r.vg_id || r.id;
+    setQText(id);
+    await lookupById(id);
+    setResults([]);
+  };
+
+  return (
+    <div className="vegu-page">
+      <MinCSpinnerOverlay open={loading} />
+
+      <div className="vegu-card">
+        {/* Back only (no Logout on this screen) */}
+        <div
+          className="minc-back-container"
+          role="button"
+          tabIndex={0}
+          onClick={() => nav("/vegu/responders")}
+          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && nav("/vegu/responders")}
+          aria-label="Back to Responders Dashboard"
+        >
+          <FaArrowLeft className="minc-back-icon" />
+          <div className="minc-back-label">Back</div>
+        </div>
+
+        <h1 className="vegu-title">Update Responder</h1>
+
+        {/* Lookup/Search */}
+        <form
+          onSubmit={handleSubmit}
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr auto",
+            gap: 10,
+            maxWidth: 720,
+            margin: "12px auto 6px",
+            position: "relative",
+          }}
+        >
+          <input
+            type="text"
+            value={qText}
+            onChange={(e) => { setQText(e.target.value); setSelectedIdx(-1); }}
+            onKeyDown={(e) => {
+              if (isLikelyId || results.length === 0) return;
+              if (e.key === "ArrowDown") { e.preventDefault(); setSelectedIdx((i) => Math.min(i + 1, results.length - 1)); }
+              else if (e.key === "ArrowUp") { e.preventDefault(); setSelectedIdx((i) => Math.max(i - 1, 0)); }
+              else if (e.key === "Enter" && selectedIdx >= 0) { e.preventDefault(); pickResult(results[selectedIdx]); }
+            }}
+            placeholder="Enter Responder ID (e.g., VG25001234) or keywords…"
+            aria-label="Responder ID or search keywords"
+            autoFocus
+            style={{
+              padding: "12px 14px",
+              borderRadius: 12,
+              border: "2px solid #9aa5b1",
+              fontFamily: "'Exo 2', sans-serif",
+              fontSize: "1rem",
+            }}
+          />
+
+          <button
+            type="submit"
+            className="btn"
+            style={{
+              padding: "12px 18px",
+              borderRadius: 12,
+              border: "2px solid #F1663D",
+              background: "#F5EE1F",
+              color: "#1B5228",
+              fontWeight: 800,
+              display: "grid",
+              gridAutoFlow: "column",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <FaSearch /> {isLikelyId ? "Lookup" : "Search"}
+          </button>
+
+          {/* Typeahead dropdown */}
+          {!isLikelyId && (results.length > 0 || searching) && (
+            <div
+              role="listbox"
+              style={{
+                position: "absolute",
+                top: "100%",
+                left: 0,
+                right: 0,
+                zIndex: 20,
+                background: "white",
+                border: "2px solid #cbd5e1",
+                borderRadius: 12,
+                marginTop: 6,
+                boxShadow: "0 10px 28px rgba(0,0,0,.12)",
+                maxHeight: 320,
+                overflowY: "auto",
+              }}
+            >
+              {searching && (
+                <div style={{ padding: "10px 12px", color: "#64748b", fontFamily: "'Exo 2', sans-serif" }}>
+                  Searching…
+                </div>
+              )}
+
+              {results.map((r, idx) => (
+                <button
+                  key={r.vg_id || r.id}
+                  type="button"
+                  onClick={() => pickResult(r)}
+                  aria-selected={idx === selectedIdx}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "auto 1fr auto",
+                    gap: 10,
+                    width: "100%",
+                    textAlign: "left",
+                    padding: "10px 12px",
+                    border: 0,
+                    cursor: "pointer",
+                    background: idx === selectedIdx ? "#fffef2" : "transparent"
+                  }}
+                >
+                  <span style={{ opacity: 0.85 }}>🧑‍💼</span>
+                  <span style={{ color: "#1B5228", fontWeight: 700 }}>
+                    {(r.first_name || r.firstName || "—") + " " + (r.last_name || r.lastName || "")}
+                    <span style={{ color: "#64748b", fontWeight: 500 }}>
+                      {" "}— {r.email || r.primary_email || "—"} {r.phone ? `(${r.phone})` : ""}
+                    </span>
+                  </span>
+                  <span style={{ fontFamily: "Orbitron, sans-serif", color: "#234a39" }}>
+                    {r.vg_id || r.id}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </form>
+
+        {/* Error */}
+        {error && (
+          <div
+            role="alert"
+            style={{
+              maxWidth: 720,
+              margin: "0 auto 12px",
+              background: "#fff6f6",
+              border: "2px solid #f3b8b8",
+              color: "#7a1d1d",
+              borderRadius: 12,
+              padding: "10px 12px",
+              fontFamily: "'Exo 2', sans-serif",
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Result (read-only preview for now) */}
+        {responder && (
+          <div
+            style={{
+              maxWidth: 980,
+              margin: "12px auto 0",
+              background: "#E8F4F9",
+              border: "2px solid #ffb300",
+              borderRadius: 16,
+              padding: 16,
+              boxShadow: "0 6px 20px rgba(0,0,0,.08)",
+            }}
+          >
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(240px,1fr))",
+                gap: 12,
+              }}
+            >
+              <Field label="VG ID" value={responder.vg_id} />
+              <Field label="First Name" value={responder.first_name || responder.firstName} />
+              <Field label="Middle Name" value={responder.middle_name || responder.middleName} />
+              <Field label="Last Name" value={responder.last_name || responder.lastName} />
+              <Field label="Email" value={responder.email || responder.primary_email} />
+              <Field label="Phone" value={responder.phone} />
+              <Field label="Department" value={responder.department} />
+              <Field label="Country" value={responder.country} />
+              <Field label="Institution ID" value={responder.institution_id} />
+              <Field label="Institution Name" value={responder.institution_name} />
+              <Field label="City" value={responder.city} />
+              <Field label="State" value={responder.state} />
+              <Field label="Updated At" value={formatLocalTs(responder.updated_at ?? responder._ts)} />
+            </div>
+
+            <div style={{ textAlign: "right", marginTop: 12 }}>
+              <button
+                type="button"
+                className="btn"
+                onClick={() => alert("Edit form will be added next.")}
+                style={{
+                  padding: "10px 16px",
+                  borderRadius: 10,
+                  border: "2px solid #F1663D",
+                  background: "#F5EE1F",
+                  color: "#1B5228",
+                  fontWeight: 800,
+                }}
+              >
+                Edit…
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value }) {
+  return (
+    <div
+      style={{
+        background: "white",
+        border: "1px solid #cbd5e1",
+        borderRadius: 10,
+        padding: "10px 12px",
+        minHeight: 52,
+      }}
+    >
+      <div style={{ fontSize: 12, color: "#475569", marginBottom: 4 }}>{label}</div>
+      <div style={{ color: "#1B5228", fontWeight: 700, wordBreak: "break-word" }}>
+        {value ?? "—"}
+      </div>
+    </div>
+  );
+}

--- a/minc-vegu-frontend/src/pages/MinCVEGUResponderUpdate.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUResponderUpdate.jsx
@@ -1,9 +1,4 @@
-// src/pages/MinCVEGUResponderUpdate.jsx  v1.4
-// - No Logout on this screen
-// - Search by Responder VG ID or keywords (name, email, phone)
-// - Uses (to-be-wired) endpoints:
-//     GET  /api/vegu-responders/{id}
-//     GET  /api/vegu-responders-search?q=<text>
+// src/pages/MinCVEGUResponderUpdate.jsx  v1.4 (F42)
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -13,6 +8,7 @@ import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
 import { FaArrowLeft, FaSearch } from "react-icons/fa";
 import { CONFIG } from "../utils/config";
 
+// ---------- helpers ----------
 const debugFetch = async (label, url, init = {}) => {
   console.log(`➡️ ${label} REQ`, url, init);
   const res = await fetch(url, init);
@@ -32,19 +28,28 @@ const makeUrl = (path, qs = "") => {
   return url;
 };
 
-// local time → readable
-function formatLocalTs(input) {
+// time formatting in responder's timezone
+function formatTsTZ(input, tz) {
   if (input === null || input === undefined || input === "") return "—";
   let d;
   try {
+    // allow epoch seconds
     if (typeof input === "number") d = new Date(input * 1000);
     else d = new Date(input);
     if (Number.isNaN(d.getTime())) return String(input);
+
     const parts = new Intl.DateTimeFormat(undefined, {
-      year: "numeric", month: "2-digit", day: "2-digit",
-      hour: "2-digit", minute: "2-digit", second: "2-digit",
-      hour12: false, timeZoneName: "short",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+      timeZone: tz || undefined,
+      timeZoneName: "short",
     }).formatToParts(d);
+
     const get = (t) => parts.find((p) => p.type === t)?.value || "";
     return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}:${get("second")} ${get("timeZoneName")}`;
   } catch {
@@ -52,8 +57,55 @@ function formatLocalTs(input) {
   }
 }
 
+const formatNowLocal = () => {
+  const parts = new Intl.DateTimeFormat(undefined, {
+    year:"numeric",month:"2-digit",day:"2-digit",
+    hour:"2-digit",minute:"2-digit",second:"2-digit",
+    hour12:false,timeZoneName:"short"
+  }).formatToParts(new Date());
+  const get = (t) => parts.find(p=>p.type===t)?.value || "";
+  return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}:${get("second")} ${get("timeZoneName")}`;
+};
+
+const getSessionUserLabel = () => {
+  try {
+    const raw = sessionStorage.getItem("mincUser");
+    const u = raw ? JSON.parse(raw) : null;
+    return (u?.displayName || u?.mincId || "MinC Admin");
+  } catch { return "MinC Admin"; }
+};
+
+// ---------- constants ----------
+const STATUS_OPTIONS = ["active","pending","suspended","locked","expired"];
+
+// Only these are editable on this screen
+const EDITABLE_FIELDS = new Set([
+  "firstName","middleName","lastName",
+  "phone","country","department","status"
+  // admin_notes is handled specially; updated_at is set on BE
+]);
+
+// ---------- component ----------
 export default function MinCVEGUResponderUpdate() {
   const nav = useNavigate();
+  const [loading, setLoading] = useState(false);
+
+  const [query, setQuery] = useState("");
+  const [selectedIdx, setSelectedIdx] = useState(-1);
+  const [results, setResults] = useState([]);
+  const [searching, setSearching] = useState(false);
+  const searchAbortRef = useRef(null);
+
+  const [responder, setResponder] = useState(null);
+  const [etag, setEtag] = useState("");
+  const [error, setError] = useState("");
+
+  const [editMode, setEditMode] = useState(false);
+  const [draft, setDraft] = useState(null);
+  const [newNote, setNewNote] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState("");
+  const [showDiscard, setShowDiscard] = useState(false);
 
   // session guard
   useEffect(() => {
@@ -61,25 +113,13 @@ export default function MinCVEGUResponderUpdate() {
     if (!u) nav("/login", { replace: true });
   }, [nav]);
 
-  const [loading, setLoading] = useState(false);
-  const [selectedIdx, setSelectedIdx] = useState(-1);
+  const isLikelyResponderId = useMemo(() => /^VG\d{2}R\d{6,}$/i.test(query.trim()), [query]);
 
-  const [qText, setQText] = useState("");
-  const [responder, setResponder] = useState(null);
-  const [error, setError] = useState("");
-
-  // typeahead
-  const [results, setResults] = useState([]);
-  const [searching, setSearching] = useState(false);
-  const searchAbortRef = useRef(null);
-
-  const isLikelyId = useMemo(() => /^VG\d{5,}$/.test(qText.trim()), [qText]);
-
-  // --- search as you type for keywords (not for full-id) ---
+  // typeahead search (by vg_id, email, names, institution_name keywords)
   useEffect(() => {
-    const q = qText.trim();
+    const q = query.trim();
     setResults([]);
-    if (!q || isLikelyId) return;
+    if (!q || isLikelyResponderId) return;
 
     const t = setTimeout(async () => {
       try {
@@ -88,10 +128,12 @@ export default function MinCVEGUResponderUpdate() {
         searchAbortRef.current = ctrl;
 
         setSearching(true);
-        const url = makeUrl(CONFIG.PATHS.RESP_SEARCH, `?q=${encodeURIComponent(q)}`);
-        const { res, json } = await debugFetch("responders-search(typeahead)", url, { method: "GET", signal: ctrl.signal });
-        if (!res.ok || json.success !== true) { setResults([]); return; }
-        // Expect: { success:true, items:[{ vg_id, first_name, last_name, email, phone, institution_id, institution_name, ... }] }
+        const url = makeUrl(CONFIG.PATHS.VEGU_RESP_SEARCH, `?q=${encodeURIComponent(q)}`);
+        const { res, json } = await debugFetch("vegu-responders-search(typeahead)", url, { method: "GET", signal: ctrl.signal });
+        if (!res.ok || json.success !== true) {
+          setResults([]);
+          return;
+        }
         setResults(Array.isArray(json.items) ? json.items.slice(0, 10) : []);
       } catch (e) {
         if (e.name !== "AbortError") console.error(e);
@@ -99,32 +141,39 @@ export default function MinCVEGUResponderUpdate() {
         setSearching(false);
       }
     }, 250);
-
     return () => clearTimeout(t);
-  }, [qText, isLikelyId]);
+  }, [query, isLikelyResponderId]);
+
+  const seedDraft = (doc) => setDraft(doc ? { ...doc } : null);
 
   const lookupById = async (id) => {
     setError("");
     setResponder(null);
+    setEtag("");
     setLoading(true);
     try {
-      const urlGet = makeUrl(`${CONFIG.PATHS.RESP_GET}/${encodeURIComponent(id)}`);
-      let { res, json } = await debugFetch("responders-get", urlGet);
-      if (res.ok && json && json.success && json.responder) {
+      const urlGet = makeUrl(`${CONFIG.PATHS.VEGU_RESP_GET}/${encodeURIComponent(id)}`);
+      let { res, json } = await debugFetch("vegu-responders-get", urlGet);
+      if (res.ok && json?.success && json?.responder) {
         setResponder(json.responder);
+        seedDraft(json.responder);
+        setEtag(json.etag || "");
         return;
       }
-      // fallback: search by q=id and pick first match
-      const urlSearch = makeUrl(CONFIG.PATHS.RESP_SEARCH, `?q=${encodeURIComponent(id)}`);
-      ({ res, json } = await debugFetch("responders-search(fallback)", urlSearch));
-      if (res.ok && json && json.success && Array.isArray(json.items) && json.items.length) {
-        setResponder(json.items[0]);
+      // fallback: search and take first
+      const urlSearch = makeUrl(CONFIG.PATHS.VEGU_RESP_SEARCH, `?q=${encodeURIComponent(id)}`);
+      ({ res, json } = await debugFetch("vegu-responders-search(fallback)", urlSearch));
+      if (res.ok && json?.success && Array.isArray(json.items) && json.items.length) {
+        const item = json.items[0];
+        setResponder(item);
+        seedDraft(item);
+        setEtag(json.etag || "");
         return;
       }
-      setError((json && json.error) || "Responder not found.");
-    } catch (e) {
-      console.error(e);
-      setError(e.message || "Network error during lookup.");
+      setError(json?.error || "Responder not found.");
+    } catch (err) {
+      console.error(err);
+      setError(err.message || "Network error during lookup.");
     } finally {
       setLoading(false);
     }
@@ -133,21 +182,24 @@ export default function MinCVEGUResponderUpdate() {
   const handleSubmit = async (e) => {
     e?.preventDefault?.();
     setError("");
-    const q = qText.trim();
-    if (!q) { setError("Please enter a Responder ID or keywords."); return; }
+    const q = query.trim();
+    if (!q) { setError("Please enter a Responder ID/email/keywords."); return; }
 
-    if (isLikelyId) { await lookupById(q); return; }
+    if (isLikelyResponderId) {
+      await lookupById(q);
+      return;
+    }
 
-    // if no live typeahead results, perform a one-shot search
+    // if we already have results, use them; otherwise do a quick search
     let list = results;
     if (!list || list.length === 0) {
       try {
         setSearching(true);
-        const url = makeUrl(CONFIG.PATHS.RESP_SEARCH, `?q=${encodeURIComponent(q)}`);
-        const { res, json } = await debugFetch("responders-search", url);
+        const url = makeUrl(CONFIG.PATHS.VEGU_RESP_SEARCH, `?q=${encodeURIComponent(q)}`);
+        const { res, json } = await debugFetch("vegu-responders-search", url);
         if (res.ok && json.success === true) list = json.items || [];
-      } catch (err) {
-        console.error(err);
+      } catch (e) {
+        console.error(e);
       } finally {
         setSearching(false);
       }
@@ -155,23 +207,94 @@ export default function MinCVEGUResponderUpdate() {
     if (list && list.length > 0) {
       await lookupById(list[0].vg_id || list[0].id);
     } else {
-      setError("No matches. Try different keywords or a full VG ID.");
+      setError("No matches. Try different keywords or a full VG Responder ID.");
     }
   };
 
   const pickResult = async (r) => {
     const id = r.vg_id || r.id;
-    setQText(id);
+    setQuery(id);
     await lookupById(id);
     setResults([]);
   };
 
+  const updateDraft = (k, v) => setDraft(d => ({ ...(d || {}), [k]: v }));
+
+  const buildPatch = () => {
+    if (!responder || !draft) return {};
+    const p = {};
+    for (const k of EDITABLE_FIELDS) {
+      if (draft[k] !== responder[k]) p[k] = draft[k];
+    }
+    return p;
+  };
+
+  const hasUnsavedChanges = () => Object.keys(buildPatch()).length > 0;
+
+  const handleSave = async () => {
+    setSaveError("");
+    const patch = buildPatch();
+    const changed = Object.keys(patch).length > 0;
+
+    if (!changed) { setEditMode(false); return; }
+
+    if (!newNote.trim()) {
+      setSaveError("Admin note is required to save changes.");
+      return;
+    }
+
+    const stamp = `[${formatNowLocal()}] ${getSessionUserLabel()}: ${newNote.trim()}`;
+    patch.admin_notes = (responder.admin_notes ? `${responder.admin_notes}\n` : "") + stamp;
+
+    setSaving(true);
+    try {
+      const url = makeUrl(CONFIG.PATHS.VEGU_RESP_UPDATE);
+      const { res, json } = await debugFetch("vegu-responders-update", url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ vg_id: responder.vg_id, etag, patch })
+      });
+
+      if (res.status === 409 && json?.error === "etag_mismatch") {
+        setSaveError("This record was modified by someone else. Please refresh and retry.");
+        if (json.etag) {
+          await lookupById(responder.vg_id); // refresh
+          setEditMode(true);
+        }
+        return;
+      }
+
+      if (!res.ok || !json?.success) {
+        setSaveError(json?.error || `Save failed (${res.status}).`);
+        return;
+      }
+
+      setResponder(json.responder);
+      seedDraft(json.responder);
+      setEtag(json.etag || "");
+      setNewNote("");
+      setEditMode(false);
+    } catch (e) {
+      console.error(e);
+      setSaveError(e.message || "Network error while saving.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // reverse-chronology notes for view
+  const notesDesc = useMemo(() => {
+    const s = responder?.admin_notes || "";
+    return s.split("\n").map(t => t.trim()).filter(Boolean).reverse();
+  }, [responder?.admin_notes]);
+
+  // ---------- UI ----------
   return (
     <div className="vegu-page">
       <MinCSpinnerOverlay open={loading} />
 
       <div className="vegu-card">
-        {/* Back only (no Logout on this screen) */}
+        {/* Back */}
         <div
           className="minc-back-container"
           role="button"
@@ -186,7 +309,7 @@ export default function MinCVEGUResponderUpdate() {
 
         <h1 className="vegu-title">Update Responder</h1>
 
-        {/* Lookup/Search */}
+        {/* Search */}
         <form
           onSubmit={handleSubmit}
           style={{
@@ -200,16 +323,16 @@ export default function MinCVEGUResponderUpdate() {
         >
           <input
             type="text"
-            value={qText}
-            onChange={(e) => { setQText(e.target.value); setSelectedIdx(-1); }}
+            value={query}
+            onChange={(e) => { setQuery(e.target.value); setSelectedIdx(-1); }}
             onKeyDown={(e) => {
-              if (isLikelyId || results.length === 0) return;
-              if (e.key === "ArrowDown") { e.preventDefault(); setSelectedIdx((i) => Math.min(i + 1, results.length - 1)); }
-              else if (e.key === "ArrowUp") { e.preventDefault(); setSelectedIdx((i) => Math.max(i - 1, 0)); }
+              if (isLikelyResponderId || results.length === 0) return;
+              if (e.key === "ArrowDown") { e.preventDefault(); setSelectedIdx(i => Math.min(i + 1, results.length - 1)); }
+              else if (e.key === "ArrowUp") { e.preventDefault(); setSelectedIdx(i => Math.max(i - 1, 0)); }
               else if (e.key === "Enter" && selectedIdx >= 0) { e.preventDefault(); pickResult(results[selectedIdx]); }
             }}
-            placeholder="Enter Responder ID (e.g., VG25001234) or keywords…"
-            aria-label="Responder ID or search keywords"
+            placeholder="Enter Responder ID/email or keywords…"
+            aria-label="Responder ID/email/keywords"
             autoFocus
             style={{
               padding: "12px 14px",
@@ -236,18 +359,17 @@ export default function MinCVEGUResponderUpdate() {
               gap: 8,
             }}
           >
-            <FaSearch /> {isLikelyId ? "Lookup" : "Search"}
+            <FaSearch /> {isLikelyResponderId ? "Lookup" : "Search"}
           </button>
 
-          {/* Typeahead dropdown */}
-          {!isLikelyId && (results.length > 0 || searching) && (
+          {/* Typeahead */}
+          {!isLikelyResponderId && (results.length > 0 || searching) && (
             <div
               role="listbox"
               style={{
                 position: "absolute",
                 top: "100%",
-                left: 0,
-                right: 0,
+                left: 0, right: 0,
                 zIndex: 20,
                 background: "white",
                 border: "2px solid #cbd5e1",
@@ -263,7 +385,6 @@ export default function MinCVEGUResponderUpdate() {
                   Searching…
                 </div>
               )}
-
               {results.map((r, idx) => (
                 <button
                   key={r.vg_id || r.id}
@@ -282,11 +403,11 @@ export default function MinCVEGUResponderUpdate() {
                     background: idx === selectedIdx ? "#fffef2" : "transparent"
                   }}
                 >
-                  <span style={{ opacity: 0.85 }}>🧑‍💼</span>
+                  <span style={{ opacity: 0.85 }}>👤</span>
                   <span style={{ color: "#1B5228", fontWeight: 700 }}>
-                    {(r.first_name || r.firstName || "—") + " " + (r.last_name || r.lastName || "")}
+                    {(r.firstName || "") + (r.lastName ? ` ${r.lastName}` : "") || r.email || "—"}
                     <span style={{ color: "#64748b", fontWeight: 500 }}>
-                      {" "}— {r.email || r.primary_email || "—"} {r.phone ? `(${r.phone})` : ""}
+                      {" "}— {r.institution_name || "—"}
                     </span>
                   </span>
                   <span style={{ fontFamily: "Orbitron, sans-serif", color: "#234a39" }}>
@@ -317,7 +438,7 @@ export default function MinCVEGUResponderUpdate() {
           </div>
         )}
 
-        {/* Result (read-only preview for now) */}
+        {/* Result */}
         {responder && (
           <div
             style={{
@@ -330,67 +451,230 @@ export default function MinCVEGUResponderUpdate() {
               boxShadow: "0 6px 20px rgba(0,0,0,.08)",
             }}
           >
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "repeat(auto-fit, minmax(240px,1fr))",
-                gap: 12,
-              }}
-            >
-              <Field label="VG ID" value={responder.vg_id} />
-              <Field label="First Name" value={responder.first_name || responder.firstName} />
-              <Field label="Middle Name" value={responder.middle_name || responder.middleName} />
-              <Field label="Last Name" value={responder.last_name || responder.lastName} />
-              <Field label="Email" value={responder.email || responder.primary_email} />
-              <Field label="Phone" value={responder.phone} />
-              <Field label="Department" value={responder.department} />
-              <Field label="Country" value={responder.country} />
-              <Field label="Institution ID" value={responder.institution_id} />
-              <Field label="Institution Name" value={responder.institution_name} />
-              <Field label="City" value={responder.city} />
-              <Field label="State" value={responder.state} />
-              <Field label="Updated At" value={formatLocalTs(responder.updated_at ?? responder._ts)} />
+            <div style={{ display:"grid", gridTemplateColumns:"repeat(auto-fit, minmax(240px,1fr))", gap:12 }}>
+              {/* read-only essentials */}
+              <Field label="VG Responder ID" value={responder.vg_id} readOnly={editMode} />
+              <Field label="Email" value={responder.email} readOnly={editMode} />
+              <Field label="Institution Name" value={responder.institution_name} readOnly={editMode} />
+              <Field label="Institution ID" value={responder.institution_id} readOnly={editMode} />
+              <Field label="Timezone" value={responder.timezone} readOnly={editMode} />
+
+              {/* editable */}
+              <RWField  edit={editMode} label="First Name"  value={draft?.firstName || ""} onChange={(v)=>updateDraft("firstName", v)} />
+              <RWField  edit={editMode} label="Middle Name" value={draft?.middleName || ""} onChange={(v)=>updateDraft("middleName", v)} />
+              <RWField  edit={editMode} label="Last Name"   value={draft?.lastName || ""} onChange={(v)=>updateDraft("lastName", v)} />
+              <RWField  edit={editMode} label="Phone"       value={draft?.phone || ""} onChange={(v)=>updateDraft("phone", v)} />
+              <RWField  edit={editMode} label="Country"     value={draft?.country || ""} onChange={(v)=>updateDraft("country", v)} />
+              <RWField  edit={editMode} label="Department"  value={draft?.department || ""} onChange={(v)=>updateDraft("department", v)} />
+              <RWSelect edit={editMode} label="Status"      value={draft?.status || ""} onChange={(v)=>updateDraft("status", v)} options={STATUS_OPTIONS} />
+
+              {/* times (rendered in responder's timezone) */}
+              <Field label="Local Created At" value={formatTsTZ(responder.local_created_at, responder.timezone)} />
+              <Field label="Created At (UTC)" value={formatTsTZ(responder.created_at, responder.timezone)} />
+              <Field label="Last Login" value={formatTsTZ(responder.last_login, responder.timezone)} />
+              <Field label="Reset Locked Until" value={formatTsTZ(responder.reset_locked_until, responder.timezone)} />
+              <Field label="Updated At" value={formatTsTZ(responder.updated_at ?? responder._ts, responder.timezone)} />
             </div>
 
-            <div style={{ textAlign: "right", marginTop: 12 }}>
+            {/* Admin notes */}
+            {!editMode && responder?.admin_notes && (
+              <div style={{ marginTop:12, background:"#fff", border:"1px solid #cbd5e1", borderRadius:10, padding:"10px 12px" }}>
+                <div style={{ fontSize:12, color:"#475569", marginBottom:4 }}>Admin Notes</div>
+                <pre style={{ margin:0, whiteSpace:"pre-wrap", fontFamily:"inherit", color:"#1B5228" }}>
+                  {notesDesc.join("\n")}
+                </pre>
+              </div>
+            )}
+
+            {editMode && (
+              <>
+                {notesDesc.length > 0 && (
+                  <div style={{ background:"#fff", border:"1px solid #cbd5e1", borderRadius:10, padding:"10px 12px", marginTop:12 }}>
+                    <div style={{ fontSize:12, color:"#475569", marginBottom:4 }}>Existing Admin Notes</div>
+                    <pre style={{ margin:0, whiteSpace:"pre-wrap", fontFamily:"inherit", color:"#1B5228" }}>
+                      {notesDesc.join("\n")}
+                    </pre>
+                  </div>
+                )}
+                <TextAreaRow
+                  label="New Admin Note (required to save changes)"
+                  value={newNote}
+                  onChange={setNewNote}
+                  placeholder="Brief reason for the change…"
+                  rows={3}
+                  required
+                />
+              </>
+            )}
+
+            {/* Actions */}
+            <div style={{ textAlign:"right", marginTop:12, display:"flex", gap:10, justifyContent:"flex-end" }}>
+              {!editMode ? (
+                <button
+                  type="button"
+                  className="btn"
+                  onClick={() => { setEditMode(true); seedDraft(responder); setSaveError(""); }}
+                  style={{ padding:"10px 16px", borderRadius:10, border:"2px solid #F1663D", background:"#F5EE1F", color:"#1B5228", fontWeight:800 }}
+                >
+                  Update…
+                </button>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={() => {
+                      if (hasUnsavedChanges() || newNote.trim()) setShowDiscard(true);
+                      else {
+                        setEditMode(false);
+                        seedDraft(responder);
+                        setNewNote("");
+                        setSaveError("");
+                      }
+                    }}
+                    style={{ padding:"10px 16px", borderRadius:10, border:"2px solid #cbd5e1", background:"#fff", color:"#334155", fontWeight:700 }}
+                    disabled={saving}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={handleSave}
+                    style={{ padding:"10px 16px", borderRadius:10, border:"2px solid #F1663D", background:"#F5EE1F", color:"#1B5228", fontWeight:800 }}
+                    disabled={saving}
+                  >
+                    {saving ? "Saving…" : "Save Changes"}
+                  </button>
+                </>
+              )}
+            </div>
+
+            {saveError && (
+              <div role="alert" style={{ marginTop:10, background:"#fff6f6", border:"2px solid #f3b8b8", color:"#7a1d1d", borderRadius:12, padding:"10px 12px", fontFamily:"'Exo 2', sans-serif" }}>
+                {saveError}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Discard dialog */}
+      {showDiscard && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="discard-title"
+          onClick={(e) => { if (e.target === e.currentTarget) setShowDiscard(false); }}
+          style={{ position:"fixed", inset:0, background:"rgba(0,0,0,.35)", display:"grid", placeItems:"center", zIndex:1000 }}
+        >
+          <div style={{ background:"white", borderRadius:14, padding:18, maxWidth:520, width:"92%", boxShadow:"0 14px 40px rgba(0,0,0,.25)", border:"2px solid #cbd5e1" }}>
+            <div id="discard-title" style={{ fontWeight:800, color:"#1B5228", marginBottom:8 }}>Discard changes?</div>
+            <div style={{ color:"#334155", marginBottom:14 }}>You have unsaved edits. If you leave now, your changes will be lost.</div>
+            <div style={{ display:"flex", gap:10, justifyContent:"flex-end" }}>
               <button
                 type="button"
+                onClick={() => setShowDiscard(false)}
                 className="btn"
-                onClick={() => alert("Edit form will be added next.")}
-                style={{
-                  padding: "10px 16px",
-                  borderRadius: 10,
-                  border: "2px solid #F1663D",
-                  background: "#F5EE1F",
-                  color: "#1B5228",
-                  fontWeight: 800,
-                }}
+                style={{ padding:"10px 16px", borderRadius:10, border:"2px solid #cbd5e1", background:"#fff", color:"#334155", fontWeight:700 }}
               >
-                Edit…
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowDiscard(false);
+                  setEditMode(false);
+                  seedDraft(responder);
+                  setNewNote("");
+                  setSaveError("");
+                }}
+                className="btn"
+                style={{ padding:"10px 16px", borderRadius:10, border:"2px solid #F1663D", background:"#F5EE1F", color:"#1B5228", fontWeight:800 }}
+              >
+                Discard Changes
               </button>
             </div>
           </div>
-        )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------- small building blocks ----------
+function Field({ label, value, readOnly = false }) {
+  const base = {
+    background: "white",
+    border: "1px solid #cbd5e1",
+    borderRadius: 10,
+    padding: "10px 12px",
+    minHeight: 52,
+  };
+  const ro = readOnly ? { background:"#f7fafc", border:"1px dashed #cbd5e1" } : {};
+  return (
+    <div style={{ ...base, ...ro }} aria-readonly={readOnly ? "true" : undefined}>
+      <div style={{ fontSize:12, color: readOnly ? "#718096" : "#475569", marginBottom:4, display:"flex", gap:6, alignItems:"center" }}>
+        {readOnly && <span aria-hidden="true">🔒</span>}
+        {label}
+      </div>
+      <div style={{ color: readOnly ? "#2f855a" : "#1B5228", fontWeight:700, wordBreak:"break-word" }}>
+        {value ?? "—"}
       </div>
     </div>
   );
 }
 
-function Field({ label, value }) {
+function InputRow({ label, value, onChange, placeholder="" }) {
   return (
-    <div
-      style={{
-        background: "white",
-        border: "1px solid #cbd5e1",
-        borderRadius: 10,
-        padding: "10px 12px",
-        minHeight: 52,
-      }}
-    >
-      <div style={{ fontSize: 12, color: "#475569", marginBottom: 4 }}>{label}</div>
-      <div style={{ color: "#1B5228", fontWeight: 700, wordBreak: "break-word" }}>
-        {value ?? "—"}
-      </div>
+    <div style={{ background:"#fff", border:"1px solid #cbd5e1", borderRadius:10, padding:"10px 12px" }}>
+      <div style={{ fontSize:12, color:"#475569", marginBottom:4 }}>{label}</div>
+      <input
+        value={value || ""}
+        onChange={(e)=>onChange(e.target.value)}
+        placeholder={placeholder}
+        style={{ width:"100%", border:"1px solid #cbd5e1", borderRadius:8, padding:"8px 10px", fontFamily:"'Exo 2', sans-serif" }}
+      />
     </div>
   );
+}
+
+function TextAreaRow({ label, value, onChange, rows=3, required=false, placeholder="" }) {
+  return (
+    <div style={{ background:"#fff", border:"1px solid #cbd5e1", borderRadius:10, padding:"10px 12px" }}>
+      <div style={{ fontSize:12, color:"#475569", marginBottom:4 }}>
+        {label}{required ? " *" : ""}
+      </div>
+      <textarea
+        value={value || ""}
+        onChange={(e)=>onChange(e.target.value)}
+        rows={rows}
+        placeholder={placeholder}
+        style={{ width:"100%", border:"1px solid #cbd5e1", borderRadius:8, padding:"8px 10px", fontFamily:"'Exo 2', sans-serif", resize:"vertical" }}
+      />
+    </div>
+  );
+}
+
+function SelectRow({ label, value, onChange, options=[] }) {
+  return (
+    <div style={{ background:"#fff", border:"1px solid #cbd5e1", borderRadius:10, padding:"10px 12px" }}>
+      <div style={{ fontSize:12, color:"#475569", marginBottom:4 }}>{label}</div>
+      <select
+        value={value || ""}
+        onChange={(e)=>onChange(e.target.value)}
+        style={{ width:"100%", border:"1px solid #cbd5e1", borderRadius:8, padding:"8px 10px", fontFamily:"'Exo 2', sans-serif" }}
+      >
+        <option value="">— Select —</option>
+        {options.map(opt => (<option key={opt} value={opt}>{opt}</option>))}
+      </select>
+    </div>
+  );
+}
+
+function RWField({ edit, label, value, onChange, placeholder }) {
+  return edit ? <InputRow label={label} value={value} onChange={onChange} placeholder={placeholder} /> : <Field label={label} value={value} />;
+}
+function RWSelect({ edit, label, value, onChange, options }) {
+  return edit ? <SelectRow label={label} value={value} onChange={onChange} options={options} /> : <Field label={label} value={value} />;
 }

--- a/minc-vegu-frontend/src/pages/MinCVEGURespondersDashboard.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGURespondersDashboard.jsx
@@ -1,0 +1,104 @@
+// src/pages/MinCVEGURespondersDashboard.jsx  v1.4 (slim actions)
+
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "../styles/MinCVeguDashboard.css";  // grid + slim actions + back/logout
+import "../styles/MinCDashboard.css";      // modal styles
+import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
+import { FaArrowLeft, FaSignOutAlt } from "react-icons/fa";
+import responderLogo from "../assets/minc-responders.png";
+
+export default function MinCVEGURespondersDashboard() {
+  const nav = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
+
+  useEffect(() => {
+    const u = sessionStorage.getItem("mincUser");
+    if (!u) nav("/login", { replace: true });
+  }, [nav]);
+
+  const go = (path) => {
+    setLoading(true);
+    setTimeout(() => nav(path), 150);
+  };
+
+  return (
+    <div className="vegu-page">
+      <MinCSpinnerOverlay open={loading} />
+
+      <div className="vegu-card">
+        {/* Back (inside card, top-left) */}
+        <div
+          className="minc-back-container"
+          role="button"
+          tabIndex={0}
+          onClick={() => nav("/minc-vegu-dashboard")}
+          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && nav("/minc-vegu-dashboard")}
+          aria-label="Back to MinC VEGU Main Dashboard"
+        >
+          <FaArrowLeft className="minc-back-icon" />
+          <div className="minc-back-label">Back</div>
+        </div>
+
+        {/* Logout (inside card, top-right) */}
+        <div
+          className="minc-logout-container"
+          role="button"
+          tabIndex={0}
+          onClick={() => setShowLogoutModal(true)}
+          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && setShowLogoutModal(true)}
+          aria-label="Logout"
+        >
+          <FaSignOutAlt className="minc-logout-icon" />
+          <div className="minc-logout-label">Logout</div>
+        </div>
+
+        <h1 className="vegu-title">Responders Actions</h1>
+
+        {/* Slim action cards */}
+<div className="minc-menu-list">
+  <button
+    className="minc-menu-item"
+    onClick={() => go("/vegu/responders/update")}
+    aria-label="Update Responder"
+  >
+    <span className="minc-menu-icon">👥</span>
+    <span className="minc-menu-label">Update Responder</span>
+  </button>
+</div>
+      </div>
+
+      {/* Confirm Logout modal */}
+      {showLogoutModal && (
+        <div className="minc-modal-backdrop" onClick={() => setShowLogoutModal(false)}>
+          <div
+            className="minc-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="logout-modal-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="logout-modal-title" className="minc-modal-title">Confirm Logout</h3>
+            <p className="minc-modal-text">Are you sure you want to logout?</p>
+            <div className="minc-modal-actions">
+              <button
+                className="btn btn-danger"
+                onClick={() => {
+                  sessionStorage.clear();
+                  setLoading(true);
+                  nav("/login", { replace: true });
+                }}
+              >
+                Yes, Logout
+              </button>
+              <button className="btn btn-secondary" onClick={() => setShowLogoutModal(false)}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/minc-vegu-frontend/src/pages/MinCVEGURespondersDashboard.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGURespondersDashboard.jsx
@@ -1,4 +1,4 @@
-// src/pages/MinCVEGURespondersDashboard.jsx  v1.4 (slim actions)
+// src/pages/MinCVEGURespondersDashboard.jsx  v1.4 
 
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -7,11 +7,15 @@ import "../styles/MinCDashboard.css";      // modal styles
 import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
 import { FaArrowLeft, FaSignOutAlt } from "react-icons/fa";
 import responderLogo from "../assets/minc-responders.png";
+import UsePageTitle from "../utils/UsePageTitle";
 
 export default function MinCVEGURespondersDashboard() {
+  
   const nav = useNavigate();
   const [loading, setLoading] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
+
+  UsePageTitle("MinC VEGU Responder Actions");
 
   useEffect(() => {
     const u = sessionStorage.getItem("mincUser");


### PR DESCRIPTION
This PR delivers feature #201 (F42), enhancing the Responder management module:

✅ Key Changes
	•	Responder Update Workflow
	•	Implemented backend + frontend support for updating responder fields (firstName, lastName, phone, country, department, status, and resetLockedUntil).
	•	Added optimistic concurrency control with ETag checks to prevent overwriting concurrent edits.
	•	Updated updated_at field automatically on every successful save.
	•	Lockout Management
	•	Introduced Reset Locked Until field:
	•	Admins can set custom lock expiration down to seconds (YYYY-MM-DD HH:MM:SS).
	•	Preserves and displays existing locked-until value before edit.
	•	Timestamps
	•	Fixed timezone conversion for last_login, reset_locked_until, and updated_at fields.
	•	All timestamps are now displayed in responder’s local timezone with proper fallback to UTC.
	•	UI/UX Improvements
	•	“Update…” mode highlights editable vs. read-only fields.
	•	Added discard confirmation modal when attempting to exit with unsaved changes.
	•	Prevents accidental navigation using Back/Exit buttons.
	•	Added page titles across all VEGU screens for clarity.
	•	Backend
	•	Refactored Cosmos DB helpers to normalize field names (snake_case ↔ camelCase).
	•	Hardened error handling and logging for responder update flow.

🧪 Testing
	•	Verified lookup, update, etag conflict handling, and lock reset flows locally.
	•	Deployed to minc-prod-func and smoke-tested end-to-end on the live web app.
	•	Confirmed timestamp conversions and admin notes append correctly.

⸻

🚀 This PR completes Responder Update (F42) functionality and is production-ready.