### PR TITLE
MinC v1.7 – F45: Reveal User (VEGU)

### DIFF
--- a/minc-vegu-backend/function_app.py
+++ b/minc-vegu-backend/function_app.py
@@ -22,3 +22,4 @@ import vegu_users_update   # noqa: F401
 import vegu_complaints_search  # noqa: F401
 import vegu_complaints_get     # noqa: F401
 import vegu_messages_thread        # noqa: F401
+import vegu_reveal_user  # noqa: F401

--- a/minc-vegu-backend/requirements.txt
+++ b/minc-vegu-backend/requirements.txt
@@ -10,8 +10,10 @@ sendgrid==6.10.0
 # Optional: logging helper or any other libs you might be using
 pytz
 
-bcrypt==4.1.2
+bcrypt==4.1.3
 
 boto3==1.34.0
 
 openai>=1.0.0
+
+cffi>=1.17.0

--- a/minc-vegu-backend/vegu_reveal_user/__init__.py
+++ b/minc-vegu-backend/vegu_reveal_user/__init__.py
@@ -1,0 +1,65 @@
+# minc-vegu-backend/vegu_reveal_user/__init__.py v1.7
+
+import json
+import logging
+import os
+import azure.functions as func
+from function_app import app
+from shared.vegu_cosmos_client import get_container
+
+bp = func.Blueprint()
+
+@app.route(
+    route="vegu/reveal-user/{complaint_vg_id}",
+    methods=["GET"],
+    auth_level=func.AuthLevel.FUNCTION,
+)
+
+def vegu_reveal_user(req: func.HttpRequest) -> func.HttpResponse:
+    """
+    Map complaint_vg_id -> user_vg_id by looking in the vgcrypt container.
+    Returns only the mapping; FE should fetch user details via Users module.
+    """
+    complaint_vg_id = (
+        req.route_params.get("complaint_vg_id")
+        or (req.params.get("complaint_vg_id") or "").strip()
+    )
+    if not complaint_vg_id:
+        return func.HttpResponse(
+            json.dumps({"success": False, "error": "Missing complaint_vg_id"}),
+            status_code=400, mimetype="application/json",
+        )
+
+    try:
+        crypt_name = os.getenv("VEGU_CRYPT_CONTAINER", "vgcrypt")
+        vgcrypt = get_container(crypt_name)
+
+        query = "SELECT TOP 1 c.user_vg_id FROM c WHERE c.complaint_vg_id=@cid"
+        params = [{"name": "@cid", "value": complaint_vg_id}]
+        items = list(vgcrypt.query_items(query=query, parameters=params, enable_cross_partition_query=True))
+
+        if not items:
+            return func.HttpResponse(
+                json.dumps({
+                    "success": False,
+                    "error": "No user mapping found for this complaint.",
+                    "complaint_vg_id": complaint_vg_id
+                }),
+                status_code=404, mimetype="application/json",
+            )
+
+        return func.HttpResponse(
+            json.dumps({
+                "success": True,
+                "complaint_vg_id": complaint_vg_id,
+                "user_vg_id": items[0].get("user_vg_id")
+            }),
+            status_code=200, mimetype="application/json",
+        )
+
+    except Exception as e:
+        logging.exception("vegu_reveal_user failed")
+        return func.HttpResponse(
+            json.dumps({"success": False, "error": str(e)}),
+            status_code=500, mimetype="application/json",
+        )

--- a/minc-vegu-frontend/src/App.jsx
+++ b/minc-vegu-frontend/src/App.jsx
@@ -15,7 +15,7 @@ import MinCVEGUUsersDashboard from "./pages/MinCVEGUUsersDashboard";
 import MinCVEGUUserUpdate from "./pages/MinCVEGUUserUpdate";
 import MinCVEGUComplaintsDashboard from "./pages/MinCVEGUComplaintsDashboard";
 import MinCVEGUComplaintReview from "./pages/MinCVEGUComplaintReview";
-
+import MinCVEGURevealUser from "./pages/MinCVEGURevealUser";
 
 
 function getSessionUser() {
@@ -73,10 +73,11 @@ function App() {
         <Route path="/vegu/responders" element={<MinCVEGURespondersDashboard />} />
         <Route path="/vegu/responders/update" element={<MinCVEGUResponderUpdate />} />
         <Route path="/vegu/users" element={<MinCVEGUUsersDashboard />} />
-        <Route path="/vegu/users/update" element={<MinCVEGUUserUpdate />} />
+        <Route path="/vegu/users/update/:vg_id?" element={<MinCVEGUUserUpdate />} />
         <Route path="/vegu/complaints" element={<MinCVEGUComplaintsDashboard />} />
         <Route path="/vegu/complaints/review" element={<MinCVEGUComplaintReview />} />
         <Route path="/vegu/complaints/review/:vg_id" element={<MinCVEGUComplaintReview />} />
+	<Route path="/vegu/complaints/reveal" element={<MinCVEGURevealUser />} />
       </Routes>
     </Router>
   );

--- a/minc-vegu-frontend/src/pages/MinCLandingPage.jsx
+++ b/minc-vegu-frontend/src/pages/MinCLandingPage.jsx
@@ -1,4 +1,4 @@
-//src/pages/MinCLandingPage.jsx 1.6
+//src/pages/MinCLandingPage.jsx 1.7
 
 import React, { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
@@ -26,7 +26,7 @@ UsePageTitle("Welcome to MinC Portal");
       <div className="landing-wrap">
         <div className="landing-card">
           <img src={mincLogo} alt="MinC Logo" className="landing-logo" />
-                    Version 1.6
+                    Version 1.7
           <div className="btn-row">
             <Link to="/login" onClick={goLogin} className="btn btn-primary" role="button">
               LOGIN

--- a/minc-vegu-frontend/src/pages/MinCVEGUComplaintsDashboard.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUComplaintsDashboard.jsx
@@ -1,15 +1,12 @@
-// src/pages/MinCVEGUComplaintsDashboard.jsx  v1.6 (F44)
+// src/pages/MinCVEGUComplaintsDashboard.jsx  v1.7 (F45)
 
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import "../styles/MinCVeguDashboard.css";
-import "../styles/MinCDashboard.css";
+import "../styles/MinCVeguDashboard.css";  // grid + slim actions + back/logout
+import "../styles/MinCDashboard.css";      // modal styles
 import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
-import { FaArrowLeft, FaSignOutAlt } from "react-icons/fa";
+import { FaArrowLeft, FaSignOutAlt, FaComments, FaUserSecret } from "react-icons/fa";
 import UsePageTitle from "../utils/UsePageTitle";
-
-// If you later add an image like assets/minc-complaints.png, you can import it and
-// swap it into the <img> below. For now we’ll use the 💬 emoji icon.
 
 export default function MinCVEGUComplaintsDashboard() {
   const nav = useNavigate();
@@ -33,7 +30,7 @@ export default function MinCVEGUComplaintsDashboard() {
       <MinCSpinnerOverlay open={loading} />
 
       <div className="vegu-card">
-        {/* Back → MinC VEGU Main Dashboard (same as Users/Responders) */}
+        {/* Back (inside card, top-left) */}
         <div
           className="minc-back-container"
           role="button"
@@ -46,7 +43,7 @@ export default function MinCVEGUComplaintsDashboard() {
           <div className="minc-back-label">Back</div>
         </div>
 
-        {/* Logout (same placement & modal as Users) */}
+        {/* Logout (inside card, top-right) */}
         <div
           className="minc-logout-container"
           role="button"
@@ -59,19 +56,32 @@ export default function MinCVEGUComplaintsDashboard() {
           <div className="minc-logout-label">Logout</div>
         </div>
 
-        <h1 className="vegu-title">Complaints Actions</h1>
+        <h1 className="vegu-title">Complaint Actions</h1>
 
-        {/* Slim action cards (match Users page styling) */}
+        {/* Slim action cards */}
         <div className="minc-menu-list">
+          {/* View Complaint */}
           <button
             className="minc-menu-item"
             onClick={() => go("/vegu/complaints/review")}
             aria-label="View Complaint"
           >
-            <span className="minc-menu-icon" aria-hidden="true" style={{ fontSize: 24, lineHeight: 1 }}>
-              💬
+            <span className="minc-menu-icon">
+              <FaComments size={26} />
             </span>
             <span className="minc-menu-label">View Complaint</span>
+          </button>
+
+          {/* NEW: Reveal User (maps complaint → user via vgcrypt) */}
+          <button
+            className="minc-menu-item"
+            onClick={() => go("/vegu/complaints/reveal")}
+            aria-label="Reveal User for Complaint"
+          >
+            <span className="minc-menu-icon">
+              <FaUserSecret size={26} />
+            </span>
+            <span className="minc-menu-label">Reveal User</span>
           </button>
         </div>
       </div>

--- a/minc-vegu-frontend/src/pages/MinCVEGURevealUser.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGURevealUser.jsx
@@ -1,0 +1,232 @@
+// MinCVEGURevealUser.jsx  v1.7 
+
+import React, { useEffect, useState, useRef } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import "../styles/MinCVeguDashboard.css";
+import "../styles/MinCDashboard.css";
+import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
+import { FaArrowLeft, FaSearch } from "react-icons/fa";
+import UsePageTitle from "../utils/UsePageTitle";
+import { CONFIG } from "../utils/config";
+
+const makeUrl = (path, tail = "") => {
+  const base = CONFIG.API_BASE || "";
+  const key  = CONFIG.API_KEY;
+  const sep  = tail.includes("?") ? "&" : "?";
+  const withKey = key ? `${tail}${sep}code=${encodeURIComponent(key)}` : tail || "";
+  const url = `${base}${path}${withKey}`;
+  console.debug("[MinC] calling:", url);
+  return url;
+};
+
+const debugFetch = async (label, url, init = {}) => {
+  console.log(`➡️ ${label} REQ`, url, init);
+  const res = await fetch(url, init);
+  const text = await res.text();
+  console.log(`⬅️ ${label} RESP ${res.status}`, text);
+  let json; try { json = JSON.parse(text); } catch { json = { parseError: true, text }; }
+  return { res, json };
+};
+
+export default function MinCVEGURevealUser() {
+  UsePageTitle("Reveal User");
+
+  const nav = useNavigate();
+  const { vg_id } = useParams();
+
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState("");
+  const [info, setInfo] = useState(null); // { complaint_vg_id, user_vg_id }
+  const [input, setInput] = useState(vg_id || "");
+  const inputRef = useRef(null);
+
+  // Normalize helper
+  const normalizeId = (s) => (s || "").toUpperCase().replace(/\s+/g, "");
+
+  // Deep-link: if vg_id param present, auto-run once
+  useEffect(() => {
+    if (vg_id) {
+      setInput(vg_id);
+      void onReveal(); // fire and forget
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vg_id]);
+
+  const onReveal = async (e) => {
+    e?.preventDefault?.();
+    setErr("");
+    setInfo(null);
+
+    const raw = inputRef.current ? inputRef.current.value : input;
+    const id  = normalizeId(raw);
+
+    if (!id) {
+      setErr("Please enter a Complaint VG-ID.");
+      return;
+    }
+
+    // Optional: soft client hint if the pattern *looks* wrong, but DO NOT BLOCK.
+    // Classic complaint ids are VG25C + 7 digits. We just warn visually.
+    const looksComplaint = /^VG\d+[A-Z]?\d*$/i.test(id); // permissive
+    if (!looksComplaint) {
+      // Show banner but continue; BE will return 404 if truly wrong.
+      setErr("Please enter a valid Complaint VG-ID (e.g., VG25C0001141). We’ll still try your input.");
+    }
+
+    try {
+      setLoading(true);
+      const url = makeUrl(`${CONFIG.PATHS.VEGU_REVEAL_USER}/${encodeURIComponent(id)}`);
+      const { res, json } = await debugFetch("vegu-reveal-user", url);
+
+      if (!res.ok || json?.success !== true) {
+        const msg = json?.error || `Lookup failed (${res.status})`;
+        setErr(msg);
+        setInfo(null);
+        return;
+      }
+
+      setInfo({ complaint_vg_id: json.complaint_vg_id, user_vg_id: json.user_vg_id });
+    } catch (e2) {
+      console.error(e2);
+      setErr(e2.message || "Reveal failed.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const goUser = () => {
+    if (info?.user_vg_id) {
+      nav(`/vegu/users/update/${encodeURIComponent(info.user_vg_id)}`);
+    }
+  };
+
+  return (
+    <div className="vegu-page">
+      <MinCSpinnerOverlay open={loading} />
+
+      <div className="vegu-card">
+        {/* Back to Complaints Actions */}
+        <div
+          className="minc-back-container"
+          role="button"
+          tabIndex={0}
+          onClick={() => nav("/vegu/complaints")}
+          onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && nav("/vegu/complaints")}
+          aria-label="Back to Complaints Actions"
+        >
+          <FaArrowLeft className="minc-back-icon" />
+          <div className="minc-back-label">Back</div>
+        </div>
+
+        <h1 className="vegu-title">Reveal User</h1>
+
+        <form
+          onSubmit={onReveal}
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr auto",
+            gap: 10,
+            maxWidth: 900,
+            margin: "0 auto 16px",
+          }}
+        >
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Enter Complaint VG-ID (e.g., VG25C0001141)…"
+            aria-label="Complaint VG-ID"
+            style={{
+              padding: "14px 16px",
+              borderRadius: 14,
+              border: "2px solid #94a3b8",
+              fontFamily: "'Exo 2', sans-serif",
+              fontSize: "1.05rem",
+            }}
+          />
+          <button
+            type="submit"
+            className="btn"
+            style={{
+              padding: "14px 20px",
+              borderRadius: 14,
+              border: "2px solid #F1663D",
+              background: "#F5EE1F",
+              color: "#1B5228",
+              fontWeight: 800,
+              display: "grid",
+              gridAutoFlow: "column",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <FaSearch /> Reveal
+          </button>
+        </form>
+
+        {/* Non-blocking hint/error */}
+        {err && (
+          <div
+            role="alert"
+            style={{
+              maxWidth: 980, margin: "0 auto 12px",
+              background:"#fff6f6", border:"2px solid #f3b8b8",
+              color:"#7a1d1d", borderRadius:12, padding:"12px 14px",
+              fontFamily:"'Exo 2', sans-serif"
+            }}
+          >
+            {err}
+          </div>
+        )}
+
+        {/* Result card */}
+        {info && (
+          <div
+            style={{
+              maxWidth: 980, margin: "0 auto",
+              background:"#f9f9f9", border:"2px solid #1B5228",
+              borderRadius:12, padding:16
+            }}
+          >
+            <div style={{ textAlign:"center", marginBottom:12 }}>
+              <div style={{ color:"#234a39", fontFamily:"Orbitron, sans-serif" }}>
+                Complaint ID: <b>{info.complaint_vg_id}</b>
+              </div>
+              <div style={{ marginTop:8, fontSize:18 }}>
+                Revealed User ID:{" "}
+                <b style={{ color:"#1B5228" }}>{info.user_vg_id || "—"}</b>
+              </div>
+            </div>
+
+            <div style={{ textAlign:"center" }}>
+              <button
+                className="btn"
+
+                onClick={() => {
+    if (info?.user_vg_id) {
+      nav(`/vegu/users/update/${encodeURIComponent(info.user_vg_id)}`);
+    }
+  }}
+
+                disabled={!info.user_vg_id}
+
+                style={{
+                  padding: "10px 16px",
+                  borderRadius: 12,
+                  border: "2px solid #1B5228",
+                  background: info.user_vg_id ? "#e2f7ea" : "#e5e7eb",
+                  color: "#1B5228",
+                  fontWeight: 700,
+                  cursor: info.user_vg_id ? "pointer" : "not-allowed"
+                }}
+              >
+                Update the User
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/minc-vegu-frontend/src/pages/MinCVEGUUserUpdate.jsx
+++ b/minc-vegu-frontend/src/pages/MinCVEGUUserUpdate.jsx
@@ -1,7 +1,7 @@
-// src/pages/MinCVEGUUserUpdate.jsx  v1.5 (F43)
+// src/pages/MinCVEGUUserUpdate.jsx  v1.7
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, UNSAFE_NavigationContext } from "react-router-dom";
+import { useNavigate, useParams, UNSAFE_NavigationContext } from "react-router-dom";
 import "../styles/MinCVeguDashboard.css";
 import "../styles/MinCDashboard.css";
 import MinCSpinnerOverlay from "../components/MinCSpinnerOverlay";
@@ -115,6 +115,27 @@ export default function MinCVEGUUserUpdate() {
   const [showDiscard, setShowDiscard] = useState(false);
 
   const pendingActionRef = useRef(null);
+
+  const { vg_id: vgParam } = useParams();
+
+useEffect(() => {
+  // If you landed here with /vegu/users/update/:vg_id,
+  // fetch that user and jump straight to the edit view.
+  (async () => {
+    if (!vgParam) return;
+
+    const id = String(vgParam).trim();
+    if (!/^VG\d{6,}$/i.test(id)) {
+      setErr("Invalid user ID in URL.");
+      setMode("search");
+      return;
+    }
+
+    setQuery(id);
+    await lookupById(id);
+  })();
+}, [vgParam]);
+
 
   // session guard
   useEffect(() => {
@@ -410,6 +431,8 @@ export default function MinCVEGUUserUpdate() {
           >
             <FaSearch /> {isLikelyUserId ? "Lookup" : "Search"}
           </button>
+
+
 
           {/* Typeahead */}
           {!isLikelyUserId && (results.length > 0 || searching) && (


### PR DESCRIPTION
	•	Adds BE endpoint: GET /api/vegu/reveal-user/{complaint_vg_id}
	•	Reads container from VEGU_CRYPT_CONTAINER
	•	FE: Complaints → Reveal User flow with deep-link to Users → Update prefilled
	•	FE: Users Update supports :vg_id route prefill + auto-jump to edit form
	•	Backend: bumped requirements.txt (bcrypt pinned)
	•	Minor fix: config path double-slash
